### PR TITLE
Warn instead of blocking when a spider name differs from its domain

### DIFF
--- a/cli/spiders.py
+++ b/cli/spiders.py
@@ -163,7 +163,13 @@ def import_spider(file, project, skip_validation):
                     )
                     return
 
-            # Validate spider name matches inspector's folder structure
+            # Sanity-check spider name vs its domain. A domain can legitimately host
+            # MORE THAN ONE spider (e.g. noaa_gov + noaa_gov_gc, or a subdomain like
+            # ncei.noaa.gov grouped as noaa_gov_ncei), so the name won't always equal
+            # the domain. Everything downstream keys off the spider NAME (only the
+            # inspector's analysis folder stays domain-derived) — warn, don't block
+            # (previously this rejected legit sub-spiders, forcing them to drop
+            # source_url to sneak in).
             if source_url:
                 from urllib.parse import urlparse
 
@@ -172,21 +178,12 @@ def import_spider(file, project, skip_validation):
                 expected_name = domain.replace(".", "_")
 
                 if spider_name != expected_name:
-                    click.echo("❌ Spider name mismatch detected!")
                     click.echo(
-                        f"   Inspector created folder: data/{project}/{expected_name}/analysis/"
+                        f"⚠️  Spider name '{spider_name}' differs from its domain "
+                        f"('{expected_name}') — fine for a secondary or sub-domain "
+                        f"spider. Crawls will live under data/{project}/{spider_name}/ "
+                        f"(inspector analysis stays under data/{project}/{expected_name}/)."
                     )
-                    click.echo(f"   But spider name is: '{spider_name}'")
-                    click.echo(
-                        f"   Crawls will save to: data/{project}/{spider_name}/crawls/"
-                    )
-                    click.echo(
-                        "\n   ⚠️  Files will be scattered across different folders!"
-                    )
-                    click.echo(
-                        f"\n   Fix: Change spider name to '{expected_name}' in the JSON config."
-                    )
-                    return
 
             # Check for existing spider
             existing = db.query(Spider).filter(Spider.name == spider_name).first()


### PR DESCRIPTION
## Problem

  `spiders import` hard-rejects any config whose spider name doesn't equal the
  domain-derived name whenever `source_url` is set. But a domain can legitimately
  host more than one spider — a second template on the same site (e.g.
  `site28_gov` + `site28_gov_gc`), or a sub-domain grouped under the main site
  (`data.site28.gov` as `site28_gov_data`). The check forced those legit sub-spiders
  to drop `source_url` just to get imported, losing the provenance field.

  ## Change
  The mismatch is now a warning instead of a rejection. It states exactly where
  the data will live: crawls under `data/<project>/<spider_name>/`, while the
  inspector's analysis folder stays domain-derived. Everything downstream
  (crawl output paths, DeltaFetch cache, checkpoint, exports, DB attribution)
  keys off the spider NAME consistently, so nothing scatters; the honest
  mismatch-shaped-folder split (crawls vs analysis) is named in the warning.

  ## Verification

  Full unit suite green. Exercised live: importing a secondary spider for an
  already-covered domain now succeeds with the warning, with `source_url` kept.