### PR TITLE
crawl-all: enqueue full crawls via Pueue instead of running inline

### DIFF
--- a/cli/crawl.py
+++ b/cli/crawl.py
@@ -225,10 +225,18 @@ def crawl_all(project, limit):
         click.echo(f"\n{'='*50}")
         click.echo(f"Running: {name}")
         click.echo(f"{'='*50}")
-        # detached=True keeps crawl_all running each spider inline, unchanged.
+        # Full crawls self-submit to Pueue like a single `crawl` (parallel,
+        # disconnect-safe); --limit runs stay inline.
         _run_spider(
-            project, name, None, limit, None, "auto", False, None, False, False, True
+            project, name, None, limit, None, "auto", False, None, False, False, False
         )
+
+    if not limit:
+        click.echo(
+            f"\n📋 All {len(spider_names)} spiders queued in Pueue "
+            "(detached; concurrency = your `pueue parallel` setting)."
+        )
+        click.echo("   Monitor: ./scrapai crawl-status   ·   pueue status")
 
 
 @click.command("crawl-status")

--- a/tests/unit/test_crawl_pueue.py
+++ b/tests/unit/test_crawl_pueue.py
@@ -41,3 +41,65 @@ def test_passes_flags_through():
     ]:
         i = cmd.index(flag)
         assert cmd[i] == flag and cmd[i + 1] == val
+
+
+# --- crawl-all queues every spider through the same detach path ---------------
+
+
+def test_crawl_all_enqueues_each_spider(monkeypatch):
+    """`crawl-all` (no --limit) must submit EVERY spider through the same
+    auto-detach path as a single `crawl` (detached=False → Pueue), not run them
+    inline — inline was sequential, terminal-bound, and died on disconnect."""
+    from unittest.mock import MagicMock, Mock, patch
+
+    from click.testing import CliRunner
+
+    import importlib
+
+    crawl_mod = importlib.import_module("cli.crawl")  # cli/__init__ shadows the
+    #                                                    attribute with the command
+    calls = []
+    monkeypatch.setattr(crawl_mod, "_run_spider", lambda *a, **k: calls.append(a))
+
+    recs = []
+    for n in ("a_org", "b_org"):
+        r = Mock()
+        r.name = n
+        recs.append(r)
+    with patch("core.db.get_db") as mock_get_db:
+        db = Mock()
+        db.query.return_value.filter.return_value.all.return_value = recs
+        cm = MagicMock()
+        cm.__enter__.return_value = db
+        mock_get_db.return_value = cm
+        res = CliRunner().invoke(crawl_mod.crawl_all, ["--project", "proj"])
+    assert res.exit_code == 0, res.output
+    assert [c[1] for c in calls] == ["a_org", "b_org"]  # every spider
+    assert all(c[10] is False for c in calls)  # detached=False → Pueue path
+    assert "queued in Pueue" in res.output
+
+
+def test_crawl_all_with_limit_stays_inline(monkeypatch):
+    from unittest.mock import MagicMock, Mock, patch
+
+    from click.testing import CliRunner
+
+    import importlib
+
+    crawl_mod = importlib.import_module("cli.crawl")
+    calls = []
+    monkeypatch.setattr(crawl_mod, "_run_spider", lambda *a, **k: calls.append(a))
+    r = Mock()
+    r.name = "a_org"
+    with patch("core.db.get_db") as mock_get_db:
+        db = Mock()
+        db.query.return_value.filter.return_value.all.return_value = [r]
+        cm = MagicMock()
+        cm.__enter__.return_value = db
+        mock_get_db.return_value = cm
+        res = CliRunner().invoke(
+            crawl_mod.crawl_all, ["--project", "proj", "--limit", "5"]
+        )
+    assert res.exit_code == 0, res.output
+    assert calls[0][3] == 5  # limit threads through
+    assert "queued in Pueue" not in res.output  # inline test mode


### PR DESCRIPTION
## Problem

  Since production crawls auto-detach into Pueue, a single `scrapai crawl` is
  parallel-safe and disconnect-safe — but `crawl-all` deliberately bypassed that
  (`detached=True` forced every spider inline). So "run the whole project" meant:
  strictly sequential, one spider at a time, bound to the terminal, and the whole
  batch dies on Ctrl+C or an SSH drop. A 15-spider project would block a terminal
  for hours with no resumability.

  ## Change

  `crawl_all` now calls each spider through the SAME path as a single `crawl`
  (`detached=False`): a full run submits itself to Pueue and returns, so the
  whole project is queued in seconds, runs at whatever concurrency the Pueue
  group is set to, and survives disconnects. `--limit N` keeps the old inline
  sequential behaviour (test crawls are foreground by design). A closing hint
  points at `./scrapai crawl-status` / `pueue status`.

  ## Verification

  - `test_crawl_all_enqueues_each_spider` — every spider goes through the detach
    path (`detached=False`), the queue hint prints.
  - `test_crawl_all_with_limit_stays_inline` — `--limit` runs stay inline, no
    queue hint.
  - Full unit suite green; used live to queue a 15-spider project.

  ## Trade-offs

  - Pueue becomes required for `crawl-all` full runs (it already was for any
    single full crawl; the error message is the same).
  - Sequential-inline behaviour, if ever wanted, is one `pueue parallel 1` away.
  - If a `pueue add` fails mid-loop, spiders after the failure aren't queued
    (the CLI exits with the same clear error a single crawl gives).