### PR TITLE
Capture robots.txt + llms.txt as crawl-time compliance witnesses

### DIFF
--- a/extensions/__init__.py
+++ b/extensions/__init__.py
@@ -1,0 +1,1 @@
+# Scrapy extensions package.

--- a/extensions/compliance_files.py
+++ b/extensions/compliance_files.py
@@ -1,0 +1,116 @@
+"""Crawl-time capture of /robots.txt and /llms.txt. When a spider opens, this
+extension schedules one request per file through the spider's OWN downloader
+(so the same Cloudflare / proxy / TLS handling as the crawl applies) and writes
+the raw body next to the crawl output, date-stamped, so the compliance snapshot
+is synced to the crawl that produced it.
+
+Enable via EXTENSIONS in settings.py:
+    "extensions.compliance_files.ComplianceFileCapture": 100
+"""
+import os
+from datetime import datetime
+from urllib.parse import urlparse
+
+from scrapy import signals, Request
+
+# Fetched once per crawl at the site root.
+COMPLIANCE_FILES = ("robots.txt", "llms.txt")
+
+
+class ComplianceFileCapture:
+    """Capture robots.txt/llms.txt through the spider's own downloader."""
+
+    def __init__(self, crawler):
+        self.crawler = crawler
+        self.spider = None
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        ext = cls(crawler)
+        crawler.signals.connect(ext.spider_opened, signal=signals.spider_opened)
+        return ext
+
+    def _base_url(self, spider):
+        """Derive the org's real site root (source_url, else first domain)."""
+        cfg = getattr(spider, "spider_config", None)
+        src = getattr(cfg, "source_url", None)
+        if src:
+            p = urlparse(src if "://" in src else "https://" + src)
+            if p.netloc:
+                return f"{p.scheme or 'https'}://{p.netloc}"
+        doms = getattr(spider, "allowed_domains", None) or []
+        return f"https://{doms[0]}" if doms else None
+
+    def spider_opened(self, spider):
+        self.spider = spider
+        base = self._base_url(spider)
+        if not base:
+            spider.logger.warning("[compliance] no source_url/allowed_domains; skipping robots/llms capture")
+            return
+        for fname in COMPLIANCE_FILES:
+            url = base.rstrip("/") + "/" + fname
+            req = Request(
+                url,
+                callback=self._save,
+                errback=self._err,
+                dont_filter=True,
+                priority=10000,
+                meta={"compliance_file": fname, "handle_httpstatus_all": True},
+            )
+            try:
+                self.crawler.engine.crawl(req)
+            except Exception as e:  # never let compliance capture break a crawl
+                spider.logger.warning(f"[compliance] could not schedule {url}: {e}")
+
+    def _save(self, response):
+        fname = response.meta.get("compliance_file", "compliance.txt")
+        # Follow redirects manually, so robots/llms are captured even when the
+        # spider has REDIRECT_ENABLED=False.
+        if response.status in (301, 302, 303, 307, 308):
+            loc = response.headers.get("Location")
+            depth = response.meta.get("compliance_redirects", 0)
+            if loc and depth < 4:
+                loc = loc.decode("latin1") if isinstance(loc, bytes) else loc
+                req = response.request.replace(
+                    url=response.urljoin(loc),
+                    meta={**response.meta, "compliance_redirects": depth + 1},
+                )
+                try:
+                    self.crawler.engine.crawl(req)
+                except Exception as e:
+                    self.spider.logger.warning(f"[compliance] redirect for {fname} not scheduled: {e}")
+            else:
+                self.spider.logger.info(f"[compliance] {fname}: redirect not followed")
+            return
+        if response.status != 200 or not response.body:
+            self.spider.logger.info(f"[compliance] {fname}: HTTP {response.status} — not saved")
+            return
+        # A real robots.txt/llms.txt is plain text and never starts with '<'.
+        # Many sites soft-404 (serve their HTML page with HTTP 200) for a missing
+        # file; skip those so we never store an HTML shell as a .txt file.
+        if response.body.lstrip(b"\xef\xbb\xbf").lstrip()[:1] == b"<":
+            self.spider.logger.info(f"[compliance] {fname}: response is HTML (no real file) — not saved")
+            return
+        spider = self.spider
+        project = getattr(getattr(spider, "spider_config", None), "project", None) or "default"
+        name = getattr(spider, "spider_name", None) or spider.name
+        # Same base dir as the crawl JSONL export (DATA_DIR is .env-configurable
+        # and cwd-independent) — the audit's witness reader looks there.
+        from core.config import DATA_DIR
+        out_dir = os.path.join(DATA_DIR, project, name, "crawls")
+        os.makedirs(out_dir, exist_ok=True)
+        stem, ext = os.path.splitext(fname)  # robots.txt -> robots, .txt
+        stamp = datetime.now().strftime("%d%m%Y")
+        path = os.path.join(out_dir, f"{stem}_{stamp}{ext}")
+        try:
+            with open(path, "wb") as fh:
+                fh.write(response.body)
+            spider.logger.info(f"[compliance] saved {fname} -> {path} ({len(response.body)} bytes)")
+        except OSError as e:
+            spider.logger.warning(f"[compliance] failed writing {path}: {e}")
+
+    def _err(self, failure):
+        req = getattr(failure, "request", None)
+        fname = (req.meta.get("compliance_file") if req else None) or "compliance file"
+        if self.spider:
+            self.spider.logger.info(f"[compliance] {fname}: fetch failed ({failure.value!r}) — not saved")

--- a/settings.py
+++ b/settings.py
@@ -74,3 +74,11 @@ logging.getLogger("nodriver").setLevel(logging.WARNING)
 logging.getLogger("websockets").setLevel(logging.WARNING)
 logging.getLogger("playwright").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+# Crawl-time compliance witnesses: capture /robots.txt + /llms.txt through the
+# spider's own downloader (same CF/proxy/TLS path) and write them beside the crawl
+# output as crawls/{robots,llms}_DDMMYYYY.txt. The audit's compliance cross-check
+# reads these as the authoritative witness against its own independent fetch.
+EXTENSIONS = {
+    "extensions.compliance_files.ComplianceFileCapture": 100,
+}

--- a/tests/unit/test_compliance_extension.py
+++ b/tests/unit/test_compliance_extension.py
@@ -1,0 +1,86 @@
+"""ComplianceFileCapture writes robots/llms witnesses beside the crawl output.
+
+Covers the three behaviours that matter: a real plain-text file is saved
+date-stamped under crawls/, an HTML soft-404 is never stored as a .txt witness,
+and redirects are re-scheduled manually (spiders may run with
+REDIRECT_ENABLED=False).
+"""
+
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from scrapy import Request
+from scrapy.http import TextResponse
+
+from extensions.compliance_files import ComplianceFileCapture
+
+pytestmark = pytest.mark.unit
+
+
+def _ext(tmp_path, monkeypatch):
+    monkeypatch.setattr("core.config.DATA_DIR", str(tmp_path / "data"))
+    ext = ComplianceFileCapture(Mock())
+    spider = Mock()
+    spider.spider_config.project = "proj"
+    spider.spider_name = "x_com"
+    ext.spider = spider
+    return ext
+
+
+def _resp(body, status=200, fname="robots.txt", headers=None, meta=None):
+    url = "https://x.com/" + fname
+    req = Request(url, meta={"compliance_file": fname, **(meta or {})})
+    return TextResponse(
+        url,
+        body=body,
+        status=status,
+        headers=headers or {},
+        request=req,
+        encoding="utf-8",
+    )
+
+
+def test_saves_plain_text_witness(tmp_path, monkeypatch):
+    ext = _ext(tmp_path, monkeypatch)
+    ext._save(_resp(b"User-agent: *\nDisallow: /admin\n"))
+    stamp = datetime.now().strftime("%d%m%Y")
+    path = tmp_path / "data" / "proj" / "x_com" / "crawls" / f"robots_{stamp}.txt"
+    assert path.read_bytes() == b"User-agent: *\nDisallow: /admin\n"
+
+
+def test_html_soft_404_not_saved(tmp_path, monkeypatch):
+    ext = _ext(tmp_path, monkeypatch)
+    ext._save(_resp(b"<!doctype html><html>Not found page</html>", fname="llms.txt"))
+    assert not (tmp_path / "data").exists()
+
+
+def test_non_200_not_saved(tmp_path, monkeypatch):
+    ext = _ext(tmp_path, monkeypatch)
+    ext._save(_resp(b"User-agent: *\n", status=404))
+    assert not (tmp_path / "data").exists()
+
+
+def test_redirect_rescheduled_with_depth(tmp_path, monkeypatch):
+    ext = _ext(tmp_path, monkeypatch)
+    ext._save(
+        _resp(b"", status=301, headers={"Location": "https://x.com/real-robots.txt"})
+    )
+    assert not (tmp_path / "data").exists()
+    (req,), _ = ext.crawler.engine.crawl.call_args
+    assert req.url == "https://x.com/real-robots.txt"
+    assert req.meta["compliance_redirects"] == 1
+
+
+def test_redirect_loop_capped(tmp_path, monkeypatch):
+    ext = _ext(tmp_path, monkeypatch)
+    ext._save(
+        _resp(
+            b"",
+            status=302,
+            headers={"Location": "https://x.com/again.txt"},
+            meta={"compliance_redirects": 4},
+        )
+    )
+    ext.crawler.engine.crawl.assert_not_called()


### PR DESCRIPTION
  ## Problem

  For compliance review you want the robots.txt / llms.txt **as the crawl saw
  them** — fetched through the same Cloudflare/proxy/TLS path as the real crawl,
  date-synced to the output they govern. A separate after-the-fact fetch can see
  a different file (or be blocked entirely on CF-protected sites the spider
  itself gets through).

  ## Change

  New `ComplianceFileCapture` extension (enabled via `EXTENSIONS` in
  `settings.py`): when a spider opens, it schedules one request per file through
  the spider's OWN downloader and writes the raw body beside the crawl output as
  `crawls/{robots,llms}_DDMMYYYY.txt`.

  Details that earn their code:

  - **Redirects are followed manually** (capped at 4 hops), so witnesses are
    captured even when the spider runs with `REDIRECT_ENABLED=False`.
  - **HTML soft-404s are never stored**: many sites serve their 200 HTML page for
    a missing file; a real robots/llms is plain text and never starts with `<`.
  - Output paths are built from the configurable `DATA_DIR` (cwd-independent),
    same as the crawl JSONL export.
  - Capture failures only log — they can never break a crawl.

  ## Verification

  5 unit tests: plain-text witness saved date-stamped under `crawls/`, HTML
  soft-404 rejected, non-200 rejected, redirect re-scheduled with depth
  tracking, redirect loop capped. Full unit suite green. Run live across a
  15-spider project migration.

  ## Notes

  - Fires on every spider open (including `--limit` test crawls) — cost is two
    requests; a same-day re-run refreshes the dated file.
  - Under a JOBDIR (checkpoint) run, Scrapy logs a harmless "Unable to serialize
    request" warning for the extension's callback and keeps the request in the
    memory queue — captured fine, just not resumable.