### PR TITLE
16 — SmartProxyMiddleware: dead-proxy detection + fail-open to direct

### DIFF
--- a/docs/requests/16-dead-proxy-fail-open.md
+++ b/docs/requests/16-dead-proxy-fail-open.md
@@ -1,6 +1,6 @@
 # 16 — SmartProxyMiddleware: dead-proxy detection + fail-open to direct
 
-**Requested by:** Ranu (2026-07-10)
+**Requested by:** MirjamOdile (2026-07-10)
 **Type:** bugfix (reliability defect — not a feature request)
 **Status:** implemented locally (middlewares.py), candidate for upstream PR
 

--- a/docs/requests/16-dead-proxy-fail-open.md
+++ b/docs/requests/16-dead-proxy-fail-open.md
@@ -1,0 +1,69 @@
+# 16 — SmartProxyMiddleware: dead-proxy detection + fail-open to direct
+
+**Requested by:** Ranu (2026-07-10)
+**Type:** bugfix (reliability defect — not a feature request)
+**Status:** implemented locally (middlewares.py), candidate for upstream PR
+
+## Problem
+
+**The bug:** the middleware escalates blocked domains onto a proxy but is blind
+to whether that proxy works — it implements no `process_exception`, so proxied
+requests that die at transport level (the only signal a broken proxy gives)
+teach it nothing. Its own escalation path can take a crawl from healthy to
+zero throughput with no error surfaced and no recovery. The fix adds the
+missing failure-detection half of a mechanism that was shipped with only its
+happy path.
+
+In auto mode, one 403/429/503 on any page adds the whole domain to
+`blocked_domains`, and every subsequent request for that domain is routed
+through the escalation proxy. The middleware has no `process_exception`, so it
+never learns when the proxy itself is broken (CONNECT refused/403, hangs). With
+a dead datacenter proxy the crawl enters a terminal state: each request burns
+`DOWNLOAD_TIMEOUT × RETRY_TIMES` through the dead proxy, throughput drops to
+zero, and the crawl either wedges indefinitely or silently under-scrapes.
+
+Observed five times in production (news_archive, 2026-07-10):
+- `site09_gov_au` / `site11_gov_au` / `site16_gov_au`: the
+  crawl-start llms.txt compliance probe 403'd → domain marked blocked → dead
+  proxy → 0-item crawls (25 min, 329/103/123 proxy attempts, 0% success).
+- `site18_eu`: ONE robots-benign privacy page 403'd at minute 1
+  → wedged at 52 pages for 2+ hours (0 pages/min).
+- `site39_int`: subdomain pages 403'd in the first seconds → wedged at 96 items.
+
+Two design flaws compound: (a) proxy health is never verified, (b) compliance
+witness probes (robots/llms fetches, which many sites 403) can poison the
+domain for the whole crawl.
+
+## Change (middlewares.py, auto mode only)
+
+1. **Dead-proxy detection**: new `process_exception` counts CONSECUTIVE
+   transport-level failures of proxied requests (any exception reaching the
+   middleware after retries); any proxied response that arrives resets the
+   counter. At 5 consecutive failures the proxy is declared dead for the crawl.
+2. **Fail-open to direct**: once dead — `blocked_domains` is cleared, no new
+   escalation happens, scheduled/retried requests carrying the proxy have it
+   stripped, and the triggering request is re-issued direct. Blocked pages then
+   just fail through the normal retry path (skip-not-poison). A loud one-time
+   log explains what happened and suggests `--proxy-type none` (site actually
+   fine direct) or `--proxy-type residential` (site truly blocks).
+3. **Compliance probes can't poison**: responses for requests carrying the
+   `compliance_file` meta (the crawl-time robots/llms witnesses) never mark the
+   domain blocked — the witness records the 403 as evidence instead.
+
+Explicit `--proxy-type residential`/`PROXY_FROM_START` crawls are NOT failed
+open (the proxy is the user's deliberate choice there); they only get the
+loud dead-proxy log.
+
+## Impact
+
+- Healthy-proxy behavior unchanged (counter resets on every proxied response).
+- Crawls with a dead/misconfigured proxy now self-heal in seconds-to-minutes
+  instead of wedging for hours; sites that serve fine direct crawl fully.
+- New stats: `proxy/transport_failure`, `proxy/declared_dead`.
+- Workaround before this change was manual: `--proxy-type none` per crawl.
+
+## Possible follow-up (not in this change)
+
+Domain blocking is still triggered by a single 403 (`blocked_domains.add` on
+first block). A threshold (e.g. 3 blocks in a window) would avoid escalating a
+whole domain over one hard-403 legal page even when the proxy is healthy.

--- a/middlewares.py
+++ b/middlewares.py
@@ -65,6 +65,14 @@ class SmartProxyMiddleware:
         # Flag to show expert-in-the-loop message only once
         self.expert_message_shown = False
 
+        # Dead-proxy detection (auto mode): consecutive transport-level failures
+        # of proxied requests. Any proxied response that arrives resets the
+        # counter; at the threshold the proxy is declared dead for this crawl
+        # and escalation fails open to direct connections (docs/requests/16).
+        self.proxy_dead = False
+        self._proxy_consecutive_failures = 0
+        self.proxy_dead_threshold = 5
+
         # Statistics
         self.stats = {
             "direct_requests": 0,
@@ -104,8 +112,17 @@ class SmartProxyMiddleware:
             self.stats["proxy_requests"] += 1
             return None
 
+        # Proxy declared dead: strip it from scheduled/retried requests so they
+        # go direct instead of burning timeouts through a broken tunnel.
+        if self.proxy_dead and self.proxy_mode == "auto" and request.meta.get("proxy"):
+            del request.meta["proxy"]
+
         # Check if this domain needs proxy (learned from previous blocks)
-        if domain in self.blocked_domains and self.proxy_available:
+        if (
+            domain in self.blocked_domains
+            and self.proxy_available
+            and not self.proxy_dead
+        ):
             if not request.meta.get("proxy"):
                 request.meta["proxy"] = self.proxy_url
                 self.stats["proxy_requests"] += 1
@@ -123,8 +140,20 @@ class SmartProxyMiddleware:
         """
         domain = urlparse(request.url).netloc
 
+        # Any proxied response arriving proves the tunnel works — reset the
+        # dead-proxy counter (blocked statuses included: that's a site answer,
+        # not a transport failure).
+        if request.meta.get("proxy"):
+            self._proxy_consecutive_failures = 0
+
         # Check for rate limiting or blocking
         if response.status in [403, 429, 503]:
+            # Compliance witness probes (robots/llms captures) must not poison
+            # the domain: many sites hard-403 them while serving content fine.
+            # The witness file records the 403 as evidence (docs/requests/16).
+            if request.meta.get("compliance_file"):
+                return response
+
             # Check if we already tried with proxy
             if request.meta.get("proxy"):
                 # Already used proxy and still blocked
@@ -145,8 +174,10 @@ class SmartProxyMiddleware:
 
                 return response
 
-            # First block - retry with proxy if available
-            if self.proxy_available:
+            # First block - retry with proxy if available (never once the
+            # proxy is declared dead: the page just fails through the normal
+            # retry path instead of poisoning the domain)
+            if self.proxy_available and not self.proxy_dead:
                 logger.warning(f"⚠️  Blocked ({response.status}): {request.url}")
                 logger.info(f"🔄 Retrying with {self.active_proxy_type} proxy...")
 
@@ -173,6 +204,57 @@ class SmartProxyMiddleware:
                 self.crawler.stats.inc_value("proxy/success")
 
         return response
+
+    def process_exception(self, request, exception):
+        """Detect a dead escalation proxy (docs/requests/16).
+
+        Exceptions reach this middleware only after RetryMiddleware gives up,
+        so each hit is a request that terminally failed at transport level.
+        Consecutive failures of PROXIED requests (a working proxy would answer
+        with SOMETHING, even a 403) mean the tunnel itself is broken — declare
+        it dead for the crawl and fail open to direct connections. Explicit
+        residential / PROXY_FROM_START crawls are the user's deliberate proxy
+        choice and are never failed open.
+        """
+        if not request.meta.get("proxy") or self.proxy_dead:
+            return None
+
+        self._proxy_consecutive_failures += 1
+        if self.crawler is not None and getattr(self.crawler, "stats", None):
+            self.crawler.stats.inc_value("proxy/transport_failure")
+
+        if (
+            self._proxy_consecutive_failures >= self.proxy_dead_threshold
+            and self.proxy_mode == "auto"
+        ):
+            self.proxy_dead = True
+            self.blocked_domains.clear()
+            if self.crawler is not None and getattr(self.crawler, "stats", None):
+                self.crawler.stats.set_value("proxy/declared_dead", 1)
+            logger.error("")
+            logger.error("=" * 80)
+            logger.error(
+                f"💀 DEAD PROXY: {self._proxy_consecutive_failures} consecutive "
+                f"transport failures through the {self.active_proxy_type} proxy "
+                f"(last: {type(exception).__name__})."
+            )
+            logger.error(
+                "   Failing open to DIRECT connections for the rest of this crawl; "
+                "blocked pages will be skipped instead of escalated."
+            )
+            logger.error(
+                "   If the site truly blocks direct traffic, re-run with "
+                "--proxy-type residential; if it serves fine, --proxy-type none."
+            )
+            logger.error("=" * 80)
+            logger.error("")
+            # Re-issue the triggering request direct
+            new_request = request.copy()
+            del new_request.meta["proxy"]
+            new_request.dont_filter = True
+            return new_request
+
+        return None
 
     def _show_expert_message(self):
         """Show expert-in-the-loop message for residential proxy escalation."""
@@ -231,6 +313,11 @@ class SmartProxyMiddleware:
         else:
             logger.info("   Proxy: not used")
         logger.info(f"   Blocked & retried: {self.stats['blocked_retries']}")
+        if self.proxy_dead:
+            logger.warning(
+                f"   💀 {self.active_proxy_type} proxy was declared DEAD mid-crawl "
+                "(failed open to direct — see docs/requests/16)"
+            )
         logger.info(f"   Blocked domains: {len(self.blocked_domains)}")
         if self.blocked_domains:
             logger.info(

--- a/tests/unit/test_proxy_dead_failopen.py
+++ b/tests/unit/test_proxy_dead_failopen.py
@@ -1,0 +1,102 @@
+"""Dead-proxy detection + fail-open to direct (docs/requests/16).
+
+A dead escalation proxy (CONNECT refused/403, hangs) used to wedge auto-mode
+crawls: one page-level 403 marked the domain blocked, every request was routed
+through the broken tunnel, and each burned timeout x retries. The middleware
+now counts consecutive transport failures of proxied requests, declares the
+proxy dead at the threshold, and fails open to direct connections. Compliance
+witness probes must never mark a domain blocked.
+"""
+
+import pytest
+from scrapy.http import Request, HtmlResponse
+
+from middlewares import SmartProxyMiddleware
+
+pytestmark = pytest.mark.unit
+
+
+def _mw(mode="auto"):
+    mw = SmartProxyMiddleware(settings=None, crawler=None)
+    mw.proxy_mode = mode
+    mw.proxy_available = True
+    mw.proxy_url = "http://p:1"
+    mw.active_proxy_type = "datacenter"
+    return mw
+
+
+def _proxied_request(url="http://x.com/a"):
+    return Request(url, meta={"proxy": "http://p:1"})
+
+
+def _response(req, status=200):
+    return HtmlResponse(url=req.url, status=status, request=req, body=b"<html></html>")
+
+
+def _fail_n(mw, n):
+    out = None
+    for i in range(n):
+        out = mw.process_exception(
+            _proxied_request(f"http://x.com/{i}"), OSError("boom")
+        )
+    return out
+
+
+def test_threshold_declares_dead_and_reissues_direct():
+    mw = _mw()
+    mw.blocked_domains.add("x.com")
+    retry = _fail_n(mw, mw.proxy_dead_threshold)
+    assert mw.proxy_dead is True
+    assert mw.blocked_domains == set()
+    assert retry is not None and "proxy" not in retry.meta
+
+
+def test_below_threshold_keeps_escalating():
+    mw = _mw()
+    assert _fail_n(mw, mw.proxy_dead_threshold - 1) is None
+    assert mw.proxy_dead is False
+
+
+def test_any_proxied_response_resets_counter():
+    mw = _mw()
+    _fail_n(mw, mw.proxy_dead_threshold - 1)
+    req = _proxied_request()
+    mw.process_response(req, _response(req, status=403))  # site answered: tunnel works
+    assert mw._proxy_consecutive_failures == 0
+    _fail_n(mw, mw.proxy_dead_threshold - 1)
+    assert mw.proxy_dead is False
+
+
+def test_direct_failures_do_not_count():
+    mw = _mw()
+    for _ in range(mw.proxy_dead_threshold + 1):
+        assert mw.process_exception(Request("http://x.com/a"), OSError("boom")) is None
+    assert mw.proxy_dead is False
+
+
+def test_dead_proxy_stops_escalation_and_strips_meta():
+    mw = _mw()
+    _fail_n(mw, mw.proxy_dead_threshold)
+    # a fresh 403 no longer escalates
+    req = Request("http://y.com/a")
+    resp = _response(req, status=403)
+    assert mw.process_response(req, resp) is resp
+    assert "y.com" not in mw.blocked_domains
+    # scheduled/retried requests still carrying the proxy get it stripped
+    stale = _proxied_request("http://x.com/z")
+    mw.process_request(stale)
+    assert "proxy" not in stale.meta
+
+
+def test_residential_mode_is_never_failed_open():
+    mw = _mw(mode="residential")
+    assert _fail_n(mw, mw.proxy_dead_threshold + 2) is None
+    assert mw.proxy_dead is False
+
+
+def test_compliance_probe_403_does_not_poison_domain():
+    mw = _mw()
+    req = Request("http://x.com/llms.txt", meta={"compliance_file": "llms_x.txt"})
+    resp = _response(req, status=403)
+    assert mw.process_response(req, resp) is resp
+    assert mw.blocked_domains == set()


### PR DESCRIPTION
**What was broken:** when a site blocked us once, all its traffic was rerouted through the escalation proxy — but nothing ever checked whether the proxy itself worked. With a dead proxy, a crawl went from healthy to zero throughput with no error shown, and either wedged for hours or silently under-collected. Observed five times in production, including crawls stuck at 52 pages for 2+ hours because a single privacy page returned a 403 in minute one.

**What it does now:** if 5 proxied requests in a row die at the network level (a working proxy always answers *something*, even a 403), the proxy is declared dead for that crawl, everything switches back to direct connections, and a loud one-time log explains what happened and what to run instead. Blocked pages then just fail through the normal retry path instead of poisoning the whole domain.

## Details

- `middlewares.py`: new `process_exception` counts consecutive transport-level failures of proxied requests; any proxied response resets the counter. On death: `blocked_domains` cleared, scheduled requests have the proxy stripped, triggering request re-issued direct. New stats: `proxy/transport_failure`, `proxy/declared_dead`.
- Compliance witness probes (robots/llms fetches, which many sites hard-403) can no longer mark a domain blocked — the witness records the 403 as evidence instead.
- Explicit `--proxy-type residential` / `PROXY_FROM_START` crawls are never failed open (the proxy is the user's deliberate choice); they only get the loud dead-proxy log.
- Request doc: `docs/requests/16-dead-proxy-fail-open.md`.

## Behavior changes

- Auto-mode crawls with a dead/misconfigured proxy now self-heal to direct connections within seconds instead of wedging for hours (the old workaround was a manual re-run with `--proxy-type none`).
- Healthy-proxy and explicit-proxy behavior unchanged.

## Verified

7 unit tests (`tests/unit/test_proxy_dead_failopen.py`): death threshold, counter reset on any proxied response, fail-open re-issue, compliance-probe immunity, explicit-proxy exemption. Not reproduced against a live dead proxy — logic-level verification only; the five production incidents are the real-world evidence of the failure mode.
