### PR TITLE
17 — Browser crawls: fail loud on a wedged service + dedicated Pueue group

### DIFF
--- a/cli/crawl.py
+++ b/cli/crawl.py
@@ -95,6 +95,53 @@ def _latest_crawl_file(project, spider):
     return files[0] if files else None
 
 
+# Browser-based crawls (CLOUDFLARE_ENABLED / BROWSER_ENABLED) all share the ONE
+# browser service; running many at once wedges it (docs/requests/17). They get
+# their own Pueue group with low parallelism so HTTP crawls can stay wide.
+BROWSER_GROUP = "scrapai-browser"
+BROWSER_GROUP_PARALLEL = 3
+
+
+def _ensure_browser_group():
+    """Create the browser Pueue group on first use. Only a newly created group
+    gets the default parallelism — an existing one keeps the user's tuning."""
+    res = subprocess.run(
+        ["pueue", "group", "add", BROWSER_GROUP], capture_output=True, text=True
+    )
+    if res.returncode == 0:
+        subprocess.run(
+            [
+                "pueue",
+                "parallel",
+                str(BROWSER_GROUP_PARALLEL),
+                "--group",
+                BROWSER_GROUP,
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+
+def _spider_transport(spider_settings, browser_flag):
+    """(cf_enabled, use_sitemap, use_repository) from the spider's DB settings
+    + the --browser CLI flag."""
+    cf_enabled = browser_flag  # CLI flag takes precedence
+    use_sitemap = False
+    use_repository = False
+    for setting in spider_settings or []:
+        if setting.key in ["CLOUDFLARE_ENABLED", "BROWSER_ENABLED"] and str(
+            setting.value
+        ).lower() in ["true", "1"]:
+            cf_enabled = True
+        if setting.key == "USE_SITEMAP" and str(setting.value).lower() in ["true", "1"]:
+            use_sitemap = True
+        # REPOSITORY_SOURCE (JSON:API / paginated-JSON repository harvest) is a
+        # JSON dict setting; its presence routes to the repository spider.
+        if setting.key == "REPOSITORY_SOURCE" and setting.value:
+            use_repository = True
+    return cf_enabled, use_sitemap, use_repository
+
+
 def _build_detached_cmd(
     scrapai_path,
     spider,
@@ -180,7 +227,7 @@ def crawl(
     detached,
 ):
     """Run a spider"""
-    _run_spider(
+    rc = _run_spider(
         project,
         spider,
         output,
@@ -193,6 +240,8 @@ def crawl(
         save_html,
         detached,
     )
+    if rc:
+        sys.exit(rc)
 
 
 @click.command()
@@ -382,6 +431,12 @@ def _run_spider(
         # so the subprocess work below can run without a live DB connection.
         spider_settings = list(db_spider.settings) if db_spider.settings else []
 
+    # Transport detection is needed BEFORE Pueue submission (browser crawls go
+    # to their own group) as well as for the crawl command below.
+    cf_enabled, use_sitemap, use_repository = _spider_transport(
+        spider_settings, browser
+    )
+
     # No --limit = production crawl: hand it to Pueue so it survives an SSH
     # disconnect. The Pueue task re-runs this command with --detached, which
     # falls through to the foreground crawl below instead of resubmitting.
@@ -418,9 +473,18 @@ def _run_spider(
             "--working-directory",
             os.getcwd(),
             "--print-task-id",
-            "--",
-            *inner,
         ]
+        if cf_enabled:
+            # Browser crawls self-limit to what the single shared browser
+            # service can sustain; HTTP crawls stay in the default group.
+            _ensure_browser_group()
+            add += ["--group", BROWSER_GROUP]
+            click.echo(
+                f"🌐 Browser crawl → Pueue group '{BROWSER_GROUP}' "
+                f"(default parallelism {BROWSER_GROUP_PARALLEL}; tune with "
+                f"`pueue parallel N --group {BROWSER_GROUP}`)"
+            )
+        add += ["--", *inner]
         res = subprocess.run(add, capture_output=True, text=True)
         if res.returncode != 0:
             click.echo(f"Failed to queue crawl via Pueue: {res.stderr.strip()}")
@@ -472,24 +536,6 @@ def _run_spider(
         click.echo("🌐 Proxy mode: none (direct connections only)")
     else:
         click.echo(f"🔀 Proxy mode: {proxy_type} (explicit, used when blocked)")
-
-    # Check if browser mode enabled (CLI flag or spider setting)
-    cf_enabled = browser  # CLI flag takes precedence
-    use_sitemap = False
-    if spider_settings:
-        for setting in spider_settings:
-            if setting.key in ["CLOUDFLARE_ENABLED", "BROWSER_ENABLED"] and str(
-                setting.value
-            ).lower() in [
-                "true",
-                "1",
-            ]:
-                cf_enabled = True
-            if setting.key == "USE_SITEMAP" and str(setting.value).lower() in [
-                "true",
-                "1",
-            ]:
-                use_sitemap = True
 
     if use_sitemap:
         spider_class = "sitemap_database_spider"
@@ -643,6 +689,20 @@ def _run_spider(
         hours = timeout / 3600
         click.echo(f"⏱️  Max runtime: {hours:.1f} hours (graceful stop)")
 
+    # Fail-loud plumbing for browser crawls: the BrowserWedgeDetector extension
+    # writes this marker when the crawl ends all-exception (wedged browser
+    # service); we turn it into a non-zero exit below (docs/requests/17).
+    wedge_marker = None
+    if cf_enabled:
+        base = (
+            Path(DATA_DIR) / project_name / spider_name
+            if project_name
+            else Path(DATA_DIR) / spider_name
+        )
+        os.makedirs(base, exist_ok=True)
+        wedge_marker = base / ".browser_wedge.json"
+        cmd.extend(["-s", f"BROWSER_WEDGE_MARKER={wedge_marker}"])
+
     if cf_enabled:
         # CloakBrowser visible by default (easier debugging)
         # On headless servers: use Xvfb or set CLOUDFLARE_HEADLESS=true
@@ -688,6 +748,29 @@ def _run_spider(
 
     result = subprocess.run(cmd)
 
+    # Fail loud on a wedged browser crawl: every request died as a handler
+    # exception, nothing was fetched — exit failed so Pueue shows it and it can
+    # be retried, instead of banking a 0-item "success" (docs/requests/17).
+    if wedge_marker and wedge_marker.exists():
+        try:
+            info = json.loads(wedge_marker.read_text())
+        except (OSError, ValueError):
+            info = {}
+        wedge_marker.unlink()
+        click.echo("")
+        click.echo("=" * 70)
+        click.echo(
+            f"💀 BROWSER CRAWL WEDGED: 0 responses, "
+            f"{info.get('exceptions', '?')} downloader exceptions, 0 items."
+        )
+        click.echo(
+            "   The shared browser service was likely dead or overloaded for the"
+        )
+        click.echo("   whole crawl. Check `./scrapai browser status`, then re-run this")
+        click.echo("   crawl. Exiting non-zero so this shows as FAILED, not done.")
+        click.echo("=" * 70)
+        return 3
+
     # Cleanup checkpoint on successful completion (production mode only)
     if checkpoint_dir and result.returncode == 0:
         checkpoint_path = Path(checkpoint_dir)
@@ -728,3 +811,7 @@ def _run_spider(
             except Exception as e:
                 click.echo(f"⚠️  S3 upload error: {e}")
                 click.echo("   File kept locally")
+
+    # Propagate the crawl's exit code (previously swallowed: any scrapy failure
+    # still exited 0, so Pueue marked failed crawls as successful).
+    return result.returncode

--- a/docs/requests/17-browser-crawl-reliability.md
+++ b/docs/requests/17-browser-crawl-reliability.md
@@ -1,0 +1,91 @@
+# 17 — Browser crawls: fail loud on a wedged service + dedicated Pueue group
+
+**Requested by:** Ranu (2026-07-15)
+**Type:** reliability defect (fail-loud) + feature (browser-crawl concurrency)
+**Status:** implemented locally (`extensions/browser_wedge.py`, `cli/crawl.py`,
+`settings.py`); the solve-probe liveness check is a documented follow-up.
+*(Numbered 18 before the 2026-07-16 renumbering — docs are now grouped
+logically, not in order of discovery.)*
+
+## Problem
+
+**The bug:** when many Cloudflare/JS crawls run in parallel they overwhelm the
+single shared browser service; it wedges (stops solving) while still reporting
+`Running`; and every browser crawl that hits it in that window exits
+**"completed successfully" with 0 items**. Nothing surfaces the failure — the
+crawl looks done, is not retried, and only a human eyeballing `downloaded 0` in
+`crawl-status` catches it. Three separate gaps compound: (a) a browser crawl
+whose requests are ~100% browser exceptions still exits success, (b) browser
+concurrency can't be capped independently of HTTP concurrency, (c) the
+service's liveness check is process-up, not solve-works.
+
+Observed in production (news_batch_1, 2026-07-15): 38 spiders submitted to Pueue
+at `parallel 8`. Every plain-HTTP / curl_cffi crawl succeeded (site12
+20,128 items; site20 22,266; site42 17,886; site13 11,156; site43
+5,869). But **14 of the browser/Cloudflare crawls finished with 0 items** in an
+~08:46–09:20 window when 8 CF verifications hit the browser at once —
+`site05_org_za, site06_org, site10_org, site14_org,
+site20_org, site21_org, site22_co_za, site24_int,
+site26_org, site27_org, site34_org_za, site35_org, site36_org, site40_org`.
+
+- `site26_org` log: `robotstxt/exception_count/<class 'Exception'>: 2`,
+  `CloudflareDownloadHandler: No browser to close`, 0 responses, 0 items — with
+  `CLOUDFLARE_ENABLED` even the robots.txt fetch routes through the (dead)
+  browser handler, so nothing loads.
+- `browser status` reported `Running (pid …)` the entire time.
+- Both a CF crawl *before* the window (`site19_org`, started 08:35, 5,375 items) and
+  one *after* (`site01_org`, started 09:03, scraping fine) succeeded — so
+  the service self-recovered; the loss was purely the peak-parallelism window.
+- Pueue marked all 14 `completed successfully`.
+
+The only lever before this change was global `pueue parallel N` and the browser
+`--pool`. `--pool 8` did not prevent the wedge (pool caps concurrent verify
+slots, not the service's ability to survive them), and dropping to
+`pueue parallel 3` throttles the fast HTTP crawls too — collective punishment
+for a browser-only problem.
+
+## Change
+
+1. **Fail loud on an all-exception browser crawl.** New
+   `extensions/browser_wedge.py`: for crawls the CLI marks as browser-based
+   (via the `BROWSER_WEDGE_MARKER` setting), `spider_closed` checks the crawl's
+   stats — **zero downloader responses + at least one downloader exception**
+   means nothing loaded and the browser path was throwing, i.e. the wedge
+   signature — and writes a small marker JSON. `cli/crawl.py` checks the marker
+   after the scrapy subprocess exits and exits **non-zero** with a loud
+   explanation, so Pueue shows `failed` instead of banking a 0-item "success".
+   `_run_spider` now also propagates the scrapy subprocess's own exit code
+   (previously swallowed — any crawl error still exited 0).
+2. **Dedicated Pueue group for browser crawls.** Production crawls whose spider
+   is browser-based (`CLOUDFLARE_ENABLED` / `BROWSER_ENABLED` / `--browser`)
+   are submitted to the `scrapai-browser` Pueue group, created on first use
+   with **parallelism 3**; an existing group is left untouched, so a user-tuned
+   parallelism survives. HTTP/curl_cffi crawls stay in the default group at
+   full width. No global throttle needed.
+
+## Impact
+
+- HTTP/curl_cffi crawls unaffected — they never touch the browser and keep
+  running wide.
+- Browser crawls self-cap at what the single service can sustain, and if it
+  wedges anyway the crawl fails visibly (and is retryable) instead of silently
+  empty.
+- A legitimately-empty re-crawl (DeltaFetch skips everything) does NOT trigger
+  the marker: skipped requests produce no downloader exceptions.
+- Workaround before this change (the incident run): `pueue parallel 3` + manual
+  re-run of the 14 empty crawls after confirming the service had recovered.
+
+## Follow-up (not in this change)
+
+- **Real liveness + self-heal:** the browser service health check should
+  exercise an actual verify (a cheap solve), not just confirm the process is
+  up, so the "`Running` but wedged" state is detectable and a crawl finding the
+  solver dead can trigger the existing auto-restart. Deferred: it modifies the
+  long-running service and cannot be verified without live CF traffic and a
+  reproduced wedge.
+- A small retry/backoff on transient verify failures inside a single crawl
+  (service slow, not dead) would further reduce empties — distinct from the
+  hard-wedge case above.
+- The wedge signature is deliberately strict (zero responses); a partial wedge
+  (some responses, then death) is not detected — upgrade path: an
+  exception-ratio threshold.

--- a/docs/requests/17-browser-crawl-reliability.md
+++ b/docs/requests/17-browser-crawl-reliability.md
@@ -1,6 +1,6 @@
 # 17 — Browser crawls: fail loud on a wedged service + dedicated Pueue group
 
-**Requested by:** Ranu (2026-07-15)
+**Requested by:** MirjamOdile (2026-07-15)
 **Type:** reliability defect (fail-loud) + feature (browser-crawl concurrency)
 **Status:** implemented locally (`extensions/browser_wedge.py`, `cli/crawl.py`,
 `settings.py`); the solve-probe liveness check is a documented follow-up.

--- a/extensions/browser_wedge.py
+++ b/extensions/browser_wedge.py
@@ -1,0 +1,66 @@
+"""Fail-loud detection for wedged browser crawls (docs/requests/17) — added for Ranu.
+
+When the shared browser service wedges, every request of a CLOUDFLARE/BROWSER
+crawl dies as a downloader exception and the crawl still ends "finished" with
+0 items — a silent empty success that Pueue banks as completed. The CLI marks
+browser-based crawls with the BROWSER_WEDGE_MARKER setting (a file path); at
+spider_closed this extension inspects the crawl's stats and writes the marker
+when the wedge signature is present: ZERO downloader responses and at least
+one downloader exception (nothing loaded, and the browser path was throwing).
+cli/crawl.py turns the marker into a non-zero exit so the crawl shows as
+failed and is retryable.
+
+A legitimately-empty re-crawl (DeltaFetch filters every request) writes no
+marker: filtered requests produce no downloader exceptions.
+"""
+
+import json
+import os
+
+from scrapy import signals
+
+
+class BrowserWedgeDetector:
+    """Write BROWSER_WEDGE_MARKER when a browser crawl ends all-exception."""
+
+    def __init__(self, crawler, marker):
+        self.crawler = crawler
+        self.marker = marker
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        marker = crawler.settings.get("BROWSER_WEDGE_MARKER")
+        ext = cls(crawler, marker)
+        # No marker path = not a browser crawl (the CLI only sets it for
+        # CLOUDFLARE/BROWSER spiders) — stay inert.
+        if marker:
+            crawler.signals.connect(ext.spider_opened, signal=signals.spider_opened)
+            crawler.signals.connect(ext.spider_closed, signal=signals.spider_closed)
+        return ext
+
+    def spider_opened(self, spider):
+        # A stale marker from a previous wedged run must not fail THIS run.
+        try:
+            os.remove(self.marker)
+        except OSError:
+            pass
+
+    def spider_closed(self, spider):
+        stats = self.crawler.stats.get_stats()
+        responses = stats.get("downloader/response_count", 0)
+        exceptions = stats.get("downloader/exception_count", 0)
+        # ponytail: strict zero-response signature — a partial wedge (some
+        # responses, then death) is not detected; upgrade path is an
+        # exception-ratio threshold.
+        if responses == 0 and exceptions > 0:
+            data = {
+                "spider": getattr(spider, "spider_name", spider.name),
+                "responses": responses,
+                "exceptions": exceptions,
+                "items": stats.get("item_scraped_count", 0),
+            }
+            try:
+                with open(self.marker, "w") as fh:
+                    json.dump(data, fh)
+            except OSError as e:  # never let wedge detection break a crawl
+                spider.logger.warning(f"[wedge] could not write marker: {e}")

--- a/settings.py
+++ b/settings.py
@@ -74,3 +74,11 @@ logging.getLogger("nodriver").setLevel(logging.WARNING)
 logging.getLogger("websockets").setLevel(logging.WARNING)
 logging.getLogger("playwright").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+# Fail-loud for browser crawls: writes BROWSER_WEDGE_MARKER when a
+# CLOUDFLARE/BROWSER crawl ends with 0 responses + downloader exceptions
+# (the wedged-service signature); cli/crawl.py exits non-zero on it.
+# Inert unless the CLI sets the marker path (docs/requests/17).
+EXTENSIONS = {
+    "extensions.browser_wedge.BrowserWedgeDetector": 110,
+}

--- a/tests/unit/test_browser_wedge.py
+++ b/tests/unit/test_browser_wedge.py
@@ -1,0 +1,112 @@
+"""Fail-loud browser-wedge detection + browser Pueue group (docs/requests/17).
+
+The wedge signature is zero downloader responses with at least one downloader
+exception: nothing loaded and the browser path was throwing. A legitimately
+empty re-crawl (DeltaFetch filters everything) has no exceptions and must not
+trigger; a partially successful crawl has responses and must not trigger.
+"""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from cli.crawl import BROWSER_GROUP, _ensure_browser_group, _spider_transport
+from extensions.browser_wedge import BrowserWedgeDetector
+
+pytestmark = pytest.mark.unit
+
+
+def _detector(tmp_path, stats):
+    crawler = Mock()
+    crawler.stats.get_stats.return_value = stats
+    marker = tmp_path / ".browser_wedge.json"
+    ext = BrowserWedgeDetector(crawler, str(marker))
+    spider = Mock()
+    spider.spider_name = "x_com"
+    return ext, spider, marker
+
+
+def test_wedge_writes_marker(tmp_path):
+    stats = {
+        "downloader/response_count": 0,
+        "downloader/exception_count": 7,
+        "item_scraped_count": 0,
+    }
+    ext, spider, marker = _detector(tmp_path, stats)
+    ext.spider_closed(spider)
+    data = json.loads(marker.read_text())
+    assert data["spider"] == "x_com"
+    assert data["exceptions"] == 7
+
+
+def test_responses_mean_no_wedge(tmp_path):
+    stats = {"downloader/response_count": 12, "downloader/exception_count": 40}
+    ext, spider, marker = _detector(tmp_path, stats)
+    ext.spider_closed(spider)
+    assert not marker.exists()
+
+
+def test_deltafetch_empty_crawl_is_not_a_wedge(tmp_path):
+    # Everything filtered before download: no responses AND no exceptions.
+    stats = {"downloader/response_count": 0, "downloader/exception_count": 0}
+    ext, spider, marker = _detector(tmp_path, stats)
+    ext.spider_closed(spider)
+    assert not marker.exists()
+
+
+def test_stale_marker_removed_on_open(tmp_path):
+    ext, spider, marker = _detector(tmp_path, {})
+    marker.write_text("{}")
+    ext.spider_opened(spider)
+    assert not marker.exists()
+
+
+def test_inert_without_marker_setting():
+    crawler = Mock()
+    crawler.settings.get.return_value = None
+    BrowserWedgeDetector.from_crawler(crawler)
+    crawler.signals.connect.assert_not_called()
+
+
+def test_group_parallelism_only_set_on_creation(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        # First invocation: `pueue group add` succeeds (new group).
+        return Mock(returncode=0 if cmd[1] == "group" else 0)
+
+    import subprocess  # the same module object cli.crawl imported
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    _ensure_browser_group()
+    assert calls[0][:3] == ["pueue", "group", "add"]
+    assert ["--group", BROWSER_GROUP] == calls[1][-2:]
+
+    # Existing group: `group add` fails -> parallelism left untouched.
+    calls.clear()
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kw: (calls.append(cmd), Mock(returncode=1))[1],
+    )
+    _ensure_browser_group()
+    assert len(calls) == 1
+
+
+def test_spider_transport_detection():
+    def setting(key, value):
+        s = Mock()
+        s.key, s.value = key, value
+        return s
+
+    cf, sm, repo = _spider_transport([setting("CLOUDFLARE_ENABLED", "true")], False)
+    assert (cf, sm, repo) == (True, False, False)
+    cf, sm, repo = _spider_transport([setting("USE_SITEMAP", "True")], False)
+    assert (cf, sm, repo) == (False, True, False)
+    cf, sm, repo = _spider_transport([setting("REPOSITORY_SOURCE", {"a": 1})], False)
+    assert repo is True
+    # --browser CLI flag alone
+    cf, sm, repo = _spider_transport([], True)
+    assert cf is True


### PR DESCRIPTION
**What was broken:** all Cloudflare/JS crawls share ONE browser service. Under 8 parallel CF verifications it wedged — still reporting "Running" while solving nothing — and every browser crawl in that window exited **"completed successfully" with 0 items**. In one production run, 14 crawls silently came back empty; only a human eyeballing a status table caught it.

**What it does now:** a browser crawl that ends with zero responses and downloader exceptions (the wedge signature) exits **FAILED**, so Pueue shows it and it can be retried. And browser crawls now queue in their own Pueue group capped at 3 concurrent, so they can't stampede the service in the first place — ordinary HTTP crawls keep running at full width.

## Details

- New `extensions/browser_wedge.py`: inert unless the CLI marks the crawl as browser-based (`BROWSER_WEDGE_MARKER` setting); at `spider_closed`, writes a marker on the wedge signature. A legitimately-empty re-crawl (DeltaFetch filters everything) has no exceptions and never triggers.
- `cli/crawl.py`: exits non-zero on the marker, and now also propagates the scrapy subprocess's own exit code (previously any crawl failure still exited 0).
- Production submission: browser-based spiders go to the `scrapai-browser` Pueue group (created on first use, parallelism 3; an existing group keeps the user's tuning).
- The solve-probe liveness check + self-heal for the service itself is a documented follow-up (can't be verified without live CF traffic).
- Request doc: `docs/requests/17-browser-crawl-reliability.md`.

## Behavior changes

- **Crawls can now exit non-zero.** Previously every crawl exited 0 no matter what; anything that assumed that (scripts, Pueue success states) will now see real failures as failures. This is the point of the change.
- `pueue status` shows a second group (`scrapai-browser`) once a browser crawl has been submitted; its parallelism (default 3) is tunable with `pueue parallel N --group scrapai-browser` and never overwritten.

## Verified

7 unit tests (`tests/unit/test_browser_wedge.py`) against synthetic stats: wedge signature, the DeltaFetch-empty non-trigger, stale-marker cleanup, inertness without the CLI marker, group-creation idempotence. **Not** reproduced against a live wedged service — that requires deliberately overloading the shared browser; the 14-empty-crawls incident is the real-world evidence.

**Merge note:** creates the `EXTENSIONS` block in `settings.py` — trivial conflict with the compliance-witnesses PR (whichever merges second combines the two entries). Also touches `cli/crawl.py`, as do PRs 18/19/21 — merging in numeric order minimizes conflicts.
