### PR TITLE
20 — show: read production crawl output by default, DB fallback

### DIFF
--- a/cli/show.py
+++ b/cli/show.py
@@ -1,4 +1,106 @@
+import json
+from pathlib import Path
+
 import click
+
+
+def _matches(rec, url, text, title):
+    """Case-insensitive substring filters, mirroring the DB branch's ilike."""
+
+    def has(field, needle):
+        return needle.lower() in str(rec.get(field) or "").lower()
+
+    if url and not has("url", url):
+        return False
+    if title and not has("title", title):
+        return False
+    if text and not (has("title", text) or has("content", text)):
+        return False
+    return True
+
+
+def _read_crawl_rows(crawls_dir, limit, url=None, text=None, title=None):
+    """(rows, file_count): the newest matching rows from crawl_*.jsonl.
+
+    Newest file first (mtime), rows within a file scanned bottom-up — crawl
+    files are append-only, so the last lines are the newest items. Mirrors the
+    DB branch's ORDER BY scraped_at DESC."""
+    files = sorted(
+        Path(crawls_dir).glob("crawl_*.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    rows = []
+    for f in files:
+        try:
+            # ponytail: whole-file read to walk lines newest-first; fine at
+            # observed corpus sizes (tens of MB) — stream if files grow to GBs.
+            lines = f.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        for line in reversed(lines):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except ValueError:
+                continue
+            if not _matches(rec, url, text, title):
+                continue
+            rows.append(rec)
+            if len(rows) >= limit:
+                return rows, len(files)
+    return rows, len(files)
+
+
+# Bulky or bookkeeping row fields never shown as extra metadata.
+_SHOWN_OR_SKIPPED = {
+    "url",
+    "title",
+    "content",
+    "author",
+    "published_date",
+    "scraped_at",
+    "html",
+    "clean_html",
+    "spider_id",
+    "spider_name",
+    "source",
+    "_callback",
+    "extracted_at",
+}
+
+
+def _echo_crawl_row(i, rec):
+    """Render one JSONL row like the DB branch renders an article."""
+    pub = str(rec.get("published_date") or "Unknown")[:10]
+    scraped = str(rec.get("scraped_at") or "Unknown")[:16].replace("T", " ")
+    click.echo(f"🔸 [{i}] {rec.get('title') or 'No Title'}")
+    click.echo(f"   📅 Published: {pub} | Scraped: {scraped}")
+    click.echo(f"   🔗 {rec.get('url')}")
+    if rec.get("author"):
+        click.echo(f"   ✍️  {rec['author']}")
+    content = rec.get("content") or ""
+    if content:
+        preview = content[:150].replace("\n", " ").strip()
+        if len(content) > 150:
+            preview += "..."
+        click.echo(f"   📝 {preview}")
+    extras = {}
+    for k, v in rec.items():
+        if k in _SHOWN_OR_SKIPPED or v in (None, "", []):
+            continue
+        if k == "metadata_json" and isinstance(v, dict):
+            extras.update(v)
+        else:
+            extras[k] = v
+    for k, v in extras.items():
+        v = str(v)
+        if len(v) > 100:
+            v = v[:100] + "..."
+        click.echo(f"   • {k}: {v}")
+    click.echo()
 
 
 @click.command()
@@ -10,8 +112,66 @@ import click
 @click.option("--url", default=None, help="Filter by URL pattern")
 @click.option("--text", "-t", default=None, help="Search title or content")
 @click.option("--title", default=None, help="Search titles only")
-def show(spider_name, project, limit, url, text, title):
-    """Show scraped articles from database"""
+@click.option(
+    "--source",
+    type=click.Choice(["auto", "crawls", "db"]),
+    default="auto",
+    help=(
+        "auto (default): production crawls/*.jsonl when present, else the DB; "
+        "crawls/db force one source (db = test-crawl items)"
+    ),
+)
+def show(spider_name, project, limit, url, text, title, source):
+    """Show scraped articles (production crawl output by default, DB fallback).
+
+    Production crawls write crawls/*.jsonl, never DB rows; the DB holds only
+    --limit test-crawl items. Showing the DB for a production spider
+    misrepresented what it collected (docs/requests/20), so crawl files win
+    when they exist.
+    """
+    from core.config import DATA_DIR
+
+    crawls_dir = Path(DATA_DIR) / project / spider_name / "crawls"
+    use_crawls = source == "crawls" or (
+        source == "auto" and any(crawls_dir.glob("crawl_*.jsonl"))
+    )
+
+    if use_crawls:
+        rows, nfiles = _read_crawl_rows(crawls_dir, limit, url, text, title)
+        filters_applied = [
+            f"{label} contains '{needle}'"
+            for label, needle in (
+                ("URL", url),
+                ("title", title),
+                ("title or content", text),
+            )
+            if needle
+        ]
+        if not rows:
+            click.echo(
+                f"📭 No matching items in production crawl files for "
+                f"'{spider_name}' ({nfiles} files)"
+            )
+            if filters_applied:
+                click.echo(f"   (with filters: {', '.join(filters_applied)})")
+            click.echo("   (test-crawl items live in the DB: --source db)")
+            return
+        click.echo(
+            f"📰 Showing {len(rows)} newest items from production crawls "
+            f"({nfiles} files) for '{spider_name}':"
+        )
+        if filters_applied:
+            click.echo(f"   (filtered by: {', '.join(filters_applied)})")
+        click.echo()
+        for i, rec in enumerate(rows, 1):
+            _echo_crawl_row(i, rec)
+        return
+
+    if source == "auto":
+        click.echo("ℹ️  No production crawl files — showing DB (test-crawl) items.")
+    else:
+        click.echo("ℹ️  Source: DB (test-crawl items).")
+
     from core.db import get_db
     from core.models import Spider, ScrapedItem
 

--- a/docs/requests/20-show-production-output.md
+++ b/docs/requests/20-show-production-output.md
@@ -1,6 +1,6 @@
 # 20 — `./scrapai show` reads production crawl output, not just the DB
 
-**Requested by:** Ranu (2026-07-16)
+**Requested by:** MirjamOdile (2026-07-16)
 **Type:** bug (misleading tool — wrong data source)
 **Status:** implemented locally (`cli/show.py`)
 *(Numbered 21 before the 2026-07-16 renumbering.)*

--- a/docs/requests/20-show-production-output.md
+++ b/docs/requests/20-show-production-output.md
@@ -1,0 +1,40 @@
+# 20 — `./scrapai show` reads production crawl output, not just the DB
+
+**Requested by:** Ranu (2026-07-16)
+**Type:** bug (misleading tool — wrong data source)
+**Status:** implemented locally (`cli/show.py`)
+*(Numbered 21 before the 2026-07-16 renumbering.)*
+
+## Problem
+
+`./scrapai show` queried only the `scraped_items` DB table, which holds
+**test-crawl / DB-pipeline** items — never the production crawl output in
+`data/<project>/<spider>/crawls/*.jsonl`. Production crawls (no `--limit`)
+write JSONL files, not DB rows. So `show` systematically misrepresented what a
+spider actually collected, while `overview` and `audit` read the real JSONL —
+the tools disagreed by design.
+
+### Observed (news_batch_1, 2026-07-15)
+
+`site03_org`: `show` returned **272** items (all stamped at the Phase-4 test
+crawl time) while the production corpus held **1,600** rows. A reviewer using
+`show` to inspect crawl output saw stale test data and drew wrong conclusions.
+
+## Change (`cli/show.py`)
+
+- Default source is now the spider's `crawls/*.jsonl` **when crawl files
+  exist**, falling back to the DB otherwise — and the output states which
+  source is shown. A fresh spider in Phase 4 (test crawl only, no crawl files
+  yet) therefore still shows its DB test items with no flag needed.
+- `--source db|crawls|auto` overrides the default — e.g. `--source db` to
+  re-verify a test crawl after production files exist.
+- The JSONL path reads its own small scanner (newest rows first, same
+  `--limit/--url/--title/--text` filters) rather than importing the quality
+  tool's corpus module, so this change is independent of the quality-tool PR.
+
+## Impact
+
+- `show` becomes trustworthy for reviewing production crawls (its main use)
+  and agrees with `overview`/`audit` on what was collected.
+- Removes a footgun that made several audit-review probes distrust `show` and
+  fall back to reading JSONL by hand.

--- a/tests/unit/test_show_crawls.py
+++ b/tests/unit/test_show_crawls.py
@@ -1,0 +1,71 @@
+"""`show` reads production crawls/*.jsonl by default (docs/requests/20).
+
+The reader must mirror the DB branch's semantics: newest items first
+(append-only files -> newest file first, lines bottom-up), case-insensitive
+substring filters, hard limit.
+"""
+
+import json
+import os
+
+import pytest
+
+from cli.show import _matches, _read_crawl_rows
+
+pytestmark = pytest.mark.unit
+
+
+def _write(path, rows, mtime):
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    os.utime(path, (mtime, mtime))
+
+
+@pytest.fixture
+def crawls(tmp_path):
+    _write(
+        tmp_path / "crawl_01072026.jsonl",
+        [
+            {"url": "https://x.com/old-1", "title": "Old one", "content": "alpha"},
+            {"url": "https://x.com/old-2", "title": "Old two", "content": "beta"},
+        ],
+        mtime=1_000,
+    )
+    _write(
+        tmp_path / "crawl_02072026_101500.jsonl",
+        [
+            {"url": "https://x.com/new-1", "title": "New one", "content": "gamma"},
+            {"url": "https://x.com/new-2", "title": "New TWO", "content": "delta"},
+        ],
+        mtime=2_000,
+    )
+    return tmp_path
+
+
+def test_newest_rows_first(crawls):
+    rows, nfiles = _read_crawl_rows(crawls, limit=3)
+    assert nfiles == 2
+    # Newest file first, its lines bottom-up, then the older file.
+    assert [r["url"].rsplit("/", 1)[1] for r in rows] == ["new-2", "new-1", "old-2"]
+
+
+def test_limit_and_filters(crawls):
+    rows, _ = _read_crawl_rows(crawls, limit=10, title="two")
+    assert {r["title"] for r in rows} == {"Old two", "New TWO"}  # case-insensitive
+    rows, _ = _read_crawl_rows(crawls, limit=1, text="alpha")
+    assert rows[0]["url"] == "https://x.com/old-1"
+    rows, _ = _read_crawl_rows(crawls, limit=10, url="/new-")
+    assert len(rows) == 2
+
+
+def test_garbage_lines_skipped(tmp_path):
+    (tmp_path / "crawl_x.jsonl").write_text('not json\n{"url": "https://x.com/a"}\n')
+    rows, _ = _read_crawl_rows(tmp_path, limit=5)
+    assert [r["url"] for r in rows] == ["https://x.com/a"]
+
+
+def test_matches_semantics():
+    rec = {"url": "https://x.com/A", "title": "Solar Report", "content": "wind text"}
+    assert _matches(rec, url="x.com", text=None, title=None)
+    assert _matches(rec, url=None, text="WIND", title=None)  # content, any case
+    assert _matches(rec, url=None, text="solar", title=None)  # or title
+    assert not _matches(rec, url=None, text=None, title="wind")  # title only


### PR DESCRIPTION
**What was broken:** `show` — the command for eyeballing what a spider collected — read only the database. But production crawls deliberately write files, never DB rows; the database holds only the little `--limit` test samples. So for any spider that had run for real, `show` displayed stale test data as if it were the collection (observed: 272 old test items shown while the real corpus held 1,600 rows), and it disagreed with `overview`/`audit` by design. Reviewers learned to distrust it.

**What it does now:** `show` reads the spider's real crawl files whenever they exist (newest items first, same `--limit/--url/--title/--text` filters), clearly states which source it's showing, and falls back to the database for fresh spiders — so the standard "test 5 items, then check" workflow works unchanged. `--source db|crawls|auto` overrides (e.g. `--source db` to re-verify a test crawl after production files exist).

## Details

- `cli/show.py`: self-contained JSONL reader (newest file first, lines bottom-up — crawl files are append-only), no quality-tool import, so this PR is independent of the quality-tool stack.
- DB branch untouched; the fallback keeps Phase-4 test verification working with no flag needed.
- Request doc: `docs/requests/20-show-production-output.md`.

## Behavior changes

- **`show`'s default source changes** for any spider that has production crawl files: it now shows the real collection instead of stale DB test samples. To inspect fresh test items on such a spider (e.g. re-testing selectors during a repair), use `--source db`.
- Fresh spiders (no crawl files yet) behave exactly as before — the Phase-4 "test 5 items then `show`" workflow needs no flag.

## Verified

5 unit tests (`tests/unit/test_show_crawls.py`): newest-first ordering across files, all three filters (case-insensitive, matching the DB branch's ilike), limit, garbage-line tolerance. The DB branch is untouched.
