### PR TITLE
21 — Repository-harvest spider: ingest JSON:API / paginated-JSON collections

### DIFF
--- a/cli/crawl.py
+++ b/cli/crawl.py
@@ -476,6 +476,7 @@ def _run_spider(
     # Check if browser mode enabled (CLI flag or spider setting)
     cf_enabled = browser  # CLI flag takes precedence
     use_sitemap = False
+    use_repository = False
     if spider_settings:
         for setting in spider_settings:
             if setting.key in ["CLOUDFLARE_ENABLED", "BROWSER_ENABLED"] and str(
@@ -490,8 +491,15 @@ def _run_spider(
                 "1",
             ]:
                 use_sitemap = True
+            # REPOSITORY_SOURCE (JSON:API / paginated-JSON repository harvest) is a
+            # JSON dict setting; its presence routes to the repository spider.
+            if setting.key == "REPOSITORY_SOURCE" and setting.value:
+                use_repository = True
 
-    if use_sitemap:
+    if use_repository:
+        spider_class = "repository_database_spider"
+        click.echo("🗄️  Using repository-harvest spider (JSON API)")
+    elif use_sitemap:
         spider_class = "sitemap_database_spider"
         click.echo("🗺️  Using sitemap spider")
     else:

--- a/docs/requests/21-jsonapi-repository-harvest.md
+++ b/docs/requests/21-jsonapi-repository-harvest.md
@@ -1,0 +1,56 @@
+# 21 — Repository-harvest spider (JSON:API / paginated-JSON) — port
+
+**Requested by:** Ranu (2026-07-13)
+**Type:** feature port (proven in the pre-migration production repo as its request 11)
+**Status:** implemented (spiders/repository_spider.py + cli/crawl.py routing), tests green
+*(Numbered 17 before the 2026-07-16 renumbering.)*
+
+## Problem
+
+Institutional repositories (Islandora/Fedora, DSpace, Samvera on Drupal fronts) are
+often un-crawlable as HTML at any polite rate: Cloudflare Turnstile on every page,
+`robots.txt Crawl-delay: 120`, a homepage-only sitemap, and broken/partial OAI-PMH.
+Yet the same sites expose a fully open, CF-free machine API (Drupal JSON:API) that
+enumerates the complete repository with pagination and inline relationship joins.
+scrapai had no way to ingest a paginated JSON collection: `USE_SITEMAP` is XML-only,
+rules/callbacks operate on HTML responses, and no processor parses JSON.
+
+Concrete case: repo.site31.edu (large institutional research repository, ~20-30k PDF
+documents). HTML crawl ≈ weeks behind Turnstile at 120 s/request; JSON:API harvest
+≈ one polite pass.
+
+## Change
+
+1. **`spiders/repository_spider.py`** — new `repository_database_spider`
+   (`BaseDBSpiderMixin` + plain `scrapy.Spider`). Walks the JSON collection endpoint
+   in `start_urls`, follows the `next` link dot-path until absent, and maps each
+   record to a normal pipeline item via the `REPOSITORY_SOURCE` setting:
+   `records`/`next`/`included_key`/`require` dot-paths plus a per-item-field `map`
+   supporting dot-paths with ` || ` fallbacks, JSON:API `include` relationship
+   resolution (indexed `(type,id)` lookup), `template` URL building, `list`
+   wrapping, and the standard `core.processors` chain. Records failing the
+   `require` field (e.g. unpublished parent node omitted from `included`) are
+   skipped, not errored.
+2. **`cli/crawl.py`** — the presence of a non-empty `REPOSITORY_SOURCE` spider
+   setting routes the crawl to `repository_database_spider` (checked alongside the
+   existing `USE_SITEMAP` routing).
+
+No existing spider path is touched; HTML/sitemap spiders behave exactly as before.
+
+## Tests
+
+`tests/unit/test_repository_spider.py` (8 tests, `pytest.mark.unit`): dot-path
+walker (dicts, list indices, negatives), `||` fallback resolution, full item
+mapping (template + include + list + processors), missing-include → null field,
+`require` skip, pagination follow, last-page stop, malformed records path, and
+item-limit pagination cutoff. Suite: 494 passed; black + flake8 clean.
+
+## Notes
+
+- The config validator caps `DOWNLOAD_DELAY` at 60, so repository spiders honoring
+  a `Crawl-delay: 120` robots directive import with `--skip-validation`
+  (politeness must be set manually in the spider JSON; Scrapy does not apply
+  robots crawl-delay itself).
+- First user: `site31_edu` (news_archive) — see its `analysis/NOTES.md` for
+  the full site investigation (broken OAI, Turnstile, JSON:API discovery) and the
+  exact `REPOSITORY_SOURCE` mapping.

--- a/docs/requests/21-jsonapi-repository-harvest.md
+++ b/docs/requests/21-jsonapi-repository-harvest.md
@@ -1,6 +1,6 @@
 # 21 — Repository-harvest spider (JSON:API / paginated-JSON) — port
 
-**Requested by:** Ranu (2026-07-13)
+**Requested by:** MirjamOdile (2026-07-13)
 **Type:** feature port (proven in the pre-migration production repo as its request 11)
 **Status:** implemented (spiders/repository_spider.py + cli/crawl.py routing), tests green
 *(Numbered 17 before the 2026-07-16 renumbering.)*

--- a/spiders/repository_spider.py
+++ b/spiders/repository_spider.py
@@ -1,0 +1,266 @@
+"""Repository-harvest spider (JSON:API / paginated-JSON) — added by Ranu.
+
+Requested in docs/requests/21-jsonapi-repository-harvest.md. Digital repositories
+(Islandora / DSpace / Fedora / Samvera) put their HTML pages behind Cloudflare
+but expose an open, CF-free machine API (Drupal JSON:API, OAI-PMH). Their sitemap
+is homepage-only and OAI is frequently broken/partial, so the JSON API is the only
+complete, reachable index. This spider treats a paginated JSON collection endpoint
+as the record inventory: it walks `links.next`, maps each record's fields to item
+fields (dot-paths + `||` fallbacks + `include` relationship resolution + `template`
++ the standard processors), and yields normal pipeline items — no browser, no proxy,
+no CF solving. Config lives entirely in `final_spider.json` under the
+`REPOSITORY_SOURCE` setting; existing HTML/sitemap spiders are untouched.
+"""
+
+import json
+import logging
+
+import scrapy
+from scrapy import Request
+
+from core.db import get_db
+from core.models import Spider
+from .base import BaseDBSpiderMixin
+
+logger = logging.getLogger(__name__)
+
+
+class RepositoryDatabaseSpider(BaseDBSpiderMixin, scrapy.Spider):
+    """Harvest a repository via its paginated JSON API (e.g. Drupal JSON:API).
+
+    Driven by the `REPOSITORY_SOURCE` setting:
+        {
+          "records": "data",              # dot-path to the record list
+          "next": "links.next.href",      # dot-path to the next-page URL (stop when absent)
+          "included_key": "included",     # where JSON:API related resources live
+          "require": "url",               # skip a record if this mapped field is empty
+          "map": { <item-field>: <spec>, ... }
+        }
+    A map <spec> is either a dot-path string (with ` || ` fallbacks resolved
+    left-to-right, first non-empty wins), or an object:
+        {"path"/"paths", "include", "template", "list", "processors"}
+      - path/paths : dot-path(s) into the record (or into the included resource
+                     when `include` is set). Supports `.` keys and numeric indices.
+      - include    : a relationship name on the record; its data (obj or first of a
+                     list) is looked up in `included[]` by (type,id) and `path` is
+                     read from THAT resource. Empty when the related resource was
+                     omitted (e.g. unpublished) -> field is null.
+      - template   : "https://host/node/{}" — {} is replaced by the scalar value.
+      - list       : true -> wrap a scalar result in a single-element list.
+      - processors : the standard core.processors chain (strip/regex/parse_datetime/...).
+    start_urls are the JSON collection endpoint(s).
+    """
+
+    name = "repository_database_spider"
+
+    def __init__(self, spider_name=None, *args, **kwargs):
+        if not spider_name:
+            spider_name = getattr(self.__class__, "_spider_name", None)
+        if not spider_name:
+            raise ValueError("spider_name argument is required")
+
+        self.spider_name = spider_name
+        self.name = spider_name  # per-spider DeltaFetch DB / output / attribution
+        self._items_scraped = 0
+        self._item_limit = None
+        self._sm_total = 0  # keeps the mixin's closed()/audit stats happy
+        self._load_config()
+        super().__init__(*args, **kwargs)
+
+    def _load_config(self):
+        with get_db() as db:
+            spider = db.query(Spider).filter(Spider.name == self.spider_name).first()
+            if not spider:
+                raise ValueError(f"Spider '{self.spider_name}' not found in database")
+            if not spider.active:
+                raise ValueError(f"Spider '{self.spider_name}' is inactive")
+
+            self.spider_config = spider
+            self.allowed_domains = spider.allowed_domains
+            self.start_urls = spider.start_urls
+
+            self._load_settings_from_db(spider)
+            self._setup_cloudflare_handlers()
+
+            source = self.custom_settings.get("REPOSITORY_SOURCE")
+            if isinstance(source, str):
+                try:
+                    source = json.loads(source)
+                except Exception:
+                    source = None
+            if not isinstance(source, dict):
+                raise ValueError(
+                    f"Spider '{self.spider_name}' has no valid REPOSITORY_SOURCE setting"
+                )
+            self._repo = source
+            self._records_path = source.get("records", "data")
+            self._next_path = source.get("next", "links.next.href")
+            self._included_key = source.get("included_key", "included")
+            self._require_field = source.get("require", "url")
+            self._map = source.get("map") or {}
+            if not self._map:
+                raise ValueError(
+                    f"REPOSITORY_SOURCE for '{self.spider_name}' has an empty 'map'"
+                )
+            logger.info(
+                f"Repository spider configured: {len(self._map)} mapped fields, "
+                f"records='{self._records_path}', next='{self._next_path}'"
+            )
+
+    @classmethod
+    def from_crawler(cls, crawler, *args, **kwargs):
+        spider = super(RepositoryDatabaseSpider, cls).from_crawler(
+            crawler, *args, **kwargs
+        )
+        cls._apply_cf_to_crawler(spider, crawler)
+        return spider
+
+    async def start(self):
+        for url in self.start_urls:
+            yield Request(url, callback=self.parse, dont_filter=True)
+
+    async def parse(self, response):
+        try:
+            doc = json.loads(response.text)
+        except Exception as e:
+            logger.error(f"Repository page not JSON ({e}): {response.url}")
+            return
+
+        included = self._index_included(doc.get(self._included_key))
+        records = self._dig(doc, self._records_path)
+        if not isinstance(records, list):
+            logger.warning(
+                f"records path '{self._records_path}' did not yield a list at "
+                f"{response.url}"
+            )
+            records = []
+
+        emitted = 0
+        for record in records:
+            try:
+                item = self._build_item(record, included)
+            except Exception as e:
+                logger.warning(f"Skipping record ({e}) at {response.url}")
+                continue
+            if item is None:
+                continue
+            yield item
+            self._items_scraped += 1
+            emitted += 1
+
+        logger.info(
+            f"Repository page {response.url}: {len(records)} records, {emitted} emitted"
+        )
+
+        # Stop paging once the item limit is reached (Scrapy's CloseSpider also
+        # enforces it, but not requesting the next page avoids over-fetching).
+        if self._item_limit and self._items_scraped >= self._item_limit:
+            return
+
+        next_url = self._dig(doc, self._next_path)
+        if isinstance(next_url, str) and next_url:
+            yield Request(next_url, callback=self.parse)
+
+    # ---- mapping helpers -------------------------------------------------
+
+    def _build_item(self, record, included):
+        """Map one JSON record to a pipeline item, or None to skip it."""
+        from core.processors import apply_processors
+
+        item = {
+            "spider_name": self.spider_name,
+            "spider_id": self.spider_config.id,
+            "source": "repository_spider",
+        }
+        for field_name, spec in self._map.items():
+            if isinstance(spec, str):
+                spec = {"path": spec}
+            elif not isinstance(spec, dict):
+                continue
+
+            base = record
+            include_rel = spec.get("include")
+            if include_rel:
+                base = self._resolve_include(record, include_rel, included)
+                if base is None:
+                    item[field_name] = None
+                    continue
+
+            value = self._first_path(base, spec.get("paths") or spec.get("path"))
+
+            template = spec.get("template")
+            if template and value not in (None, "", []):
+                value = template.replace("{}", str(value))
+
+            if spec.get("list") and value not in (None, "", []):
+                value = value if isinstance(value, list) else [value]
+
+            processors = spec.get("processors") or []
+            if processors:
+                try:
+                    value = apply_processors(value, processors)
+                except Exception as e:
+                    logger.warning(
+                        f"REPOSITORY_SOURCE processor failed for '{field_name}': {e}"
+                    )
+            item[field_name] = value
+
+        require = self._require_field
+        if require and not item.get(require):
+            return None
+        return item
+
+    def _resolve_include(self, record, relationship, included):
+        """Follow a JSON:API relationship to its resource in `included`."""
+        rel = self._dig(record, f"relationships.{relationship}.data")
+        if isinstance(rel, list):
+            rel = rel[0] if rel else None
+        if not isinstance(rel, dict):
+            return None
+        key = (rel.get("type"), rel.get("id"))
+        return included.get(key)
+
+    @staticmethod
+    def _index_included(included):
+        """Index JSON:API `included[]` by (type, id) for O(1) relationship lookup."""
+        index = {}
+        if isinstance(included, list):
+            for res in included:
+                if isinstance(res, dict):
+                    index[(res.get("type"), res.get("id"))] = res
+        return index
+
+    def _first_path(self, obj, paths):
+        """Resolve the first non-empty dot-path. `paths` may be a string
+        (optionally with ` || ` alternatives) or a list of strings."""
+        if paths is None:
+            return None
+        if isinstance(paths, str):
+            candidates = [p.strip() for p in paths.split("||")]
+        else:
+            candidates = list(paths)
+        for path in candidates:
+            value = self._dig(obj, path)
+            if value not in (None, "", []):
+                return value
+        return None
+
+    @staticmethod
+    def _dig(obj, path):
+        """Walk a dot-path (dict keys + numeric list indices) into `obj`."""
+        if not path:
+            return obj
+        cur = obj
+        for key in str(path).split("."):
+            if isinstance(cur, dict):
+                cur = cur.get(key)
+            elif isinstance(cur, list):
+                if key.lstrip("-").isdigit() and -len(cur) <= int(key) < len(cur):
+                    cur = cur[int(key)]
+                else:
+                    return None
+            else:
+                return None
+            if cur is None:
+                return None
+        return cur

--- a/tests/unit/test_repository_spider.py
+++ b/tests/unit/test_repository_spider.py
@@ -1,0 +1,189 @@
+"""Unit tests for the repository-harvest spider (REPOSITORY_SOURCE / JSON:API).
+
+The spider maps paginated JSON collection records to pipeline items. These tests
+exercise the pure mapping layer (dot-paths, fallbacks, includes, templates,
+processors, require-skip) and the parse/pagination flow without any DB access:
+the spider is constructed via object.__new__ and configured directly.
+"""
+
+import json
+
+import pytest
+from scrapy.http import Request, TextResponse
+
+from spiders.repository_spider import RepositoryDatabaseSpider
+
+pytestmark = pytest.mark.unit
+
+
+def make_spider(source):
+    spider = object.__new__(RepositoryDatabaseSpider)
+    spider.spider_name = "repo_test"
+    spider._items_scraped = 0
+    spider._item_limit = None
+    spider._repo = source
+    spider._records_path = source.get("records", "data")
+    spider._next_path = source.get("next", "links.next.href")
+    spider._included_key = source.get("included_key", "included")
+    spider._require_field = source.get("require", "url")
+    spider._map = source.get("map") or {}
+
+    class _Cfg:
+        id = 42
+
+    spider.spider_config = _Cfg()
+    return spider
+
+
+def make_response(doc, url="https://repo.example/jsonapi/node/thing"):
+    return TextResponse(
+        url=url,
+        body=json.dumps(doc).encode(),
+        encoding="utf-8",
+        request=Request(url),
+    )
+
+
+async def collect(gen):
+    return [x async for x in gen] if hasattr(gen, "__anext__") else list(gen)
+
+
+BASIC_SOURCE = {
+    "records": "data",
+    "next": "links.next.href",
+    "require": "url",
+    "map": {
+        "url": {
+            "path": "attributes.nid",
+            "template": "https://repo.example/node/{}",
+        },
+        "title": "attributes.display_title || attributes.title",
+        "published_date": {
+            "path": "attributes.date_issued.0",
+            "processors": [{"type": "parse_datetime"}],
+        },
+        "pdf_urls": {
+            "include": "file",
+            "path": "attributes.uri.url",
+            "template": "https://repo.example{}",
+            "list": True,
+        },
+    },
+}
+
+
+def record(nid, title=None, display=None, date=None, file_id=None):
+    rec = {
+        "type": "node--thing",
+        "id": f"uuid-{nid}",
+        "attributes": {
+            "nid": nid,
+            "title": title,
+            "display_title": display,
+            "date_issued": [date] if date else [],
+        },
+        "relationships": {},
+    }
+    if file_id:
+        rec["relationships"]["file"] = {
+            "data": {"type": "media--document", "id": file_id}
+        }
+    return rec
+
+
+def included_file(file_id, path):
+    return {
+        "type": "media--document",
+        "id": file_id,
+        "attributes": {"uri": {"url": path}},
+    }
+
+
+def test_dig_walks_dicts_lists_and_negative_indices():
+    dig = RepositoryDatabaseSpider._dig
+    obj = {"a": {"b": [{"c": 1}, {"c": 2}]}}
+    assert dig(obj, "a.b.0.c") == 1
+    assert dig(obj, "a.b.-1.c") == 2
+    assert dig(obj, "a.b.5.c") is None
+    assert dig(obj, "a.missing") is None
+    assert dig(obj, "") == obj
+
+
+def test_first_path_fallbacks_first_nonempty_wins():
+    spider = make_spider(BASIC_SOURCE)
+    obj = {"attributes": {"display_title": "", "title": "Real Title"}}
+    value = spider._first_path(obj, "attributes.display_title || attributes.title")
+    assert value == "Real Title"
+    assert spider._first_path(obj, ["attributes.nope", "attributes.title"]) == (
+        "Real Title"
+    )
+    assert spider._first_path(obj, None) is None
+
+
+def test_build_item_maps_template_include_list_and_processors():
+    spider = make_spider(BASIC_SOURCE)
+    rec = record(7, title="T", date="1998-05-01", file_id="f1")
+    included = spider._index_included([included_file("f1", "/files/report.pdf")])
+    item = spider._build_item(rec, included)
+    assert item["url"] == "https://repo.example/node/7"
+    assert item["title"] == "T"
+    assert str(item["published_date"]).startswith("1998-05-01")
+    assert item["pdf_urls"] == ["https://repo.example/files/report.pdf"]
+    assert item["spider_id"] == 42
+    assert item["source"] == "repository_spider"
+
+
+def test_build_item_missing_include_yields_null_field_not_crash():
+    spider = make_spider(BASIC_SOURCE)
+    rec = record(8, title="T", file_id="ghost")  # relationship present, not included
+    item = spider._build_item(rec, included={})
+    assert item["pdf_urls"] is None
+    assert item["url"] == "https://repo.example/node/8"
+
+
+def test_build_item_require_skips_records_without_url():
+    spider = make_spider(BASIC_SOURCE)
+    rec = record(None, title="unpublished parent")
+    rec["attributes"]["nid"] = None
+    assert spider._build_item(rec, included={}) is None
+
+
+@pytest.mark.asyncio
+async def test_parse_emits_items_and_follows_next_link():
+    spider = make_spider(BASIC_SOURCE)
+    doc = {
+        "data": [record(1, title="A"), record(2, title="B")],
+        "links": {"next": {"href": "https://repo.example/jsonapi?page[offset]=50"}},
+    }
+    results = [x async for x in spider.parse(make_response(doc))]
+    items = [r for r in results if isinstance(r, dict)]
+    requests = [r for r in results if isinstance(r, Request)]
+    assert [i["url"] for i in items] == [
+        "https://repo.example/node/1",
+        "https://repo.example/node/2",
+    ]
+    assert len(requests) == 1
+    assert "offset" in requests[0].url
+
+
+@pytest.mark.asyncio
+async def test_parse_stops_paging_on_last_page_and_bad_records_path():
+    spider = make_spider(BASIC_SOURCE)
+    last_page = {"data": [record(3, title="C")], "links": {}}
+    results = [x async for x in spider.parse(make_response(last_page))]
+    assert all(isinstance(r, dict) for r in results)
+
+    not_a_list = {"data": {"oops": 1}, "links": {}}
+    assert [x async for x in spider.parse(make_response(not_a_list))] == []
+
+
+@pytest.mark.asyncio
+async def test_parse_item_limit_stops_pagination():
+    spider = make_spider(BASIC_SOURCE)
+    spider._item_limit = 1
+    doc = {
+        "data": [record(1, title="A"), record(2, title="B")],
+        "links": {"next": {"href": "https://repo.example/jsonapi?page[offset]=50"}},
+    }
+    results = [x async for x in spider.parse(make_response(doc))]
+    assert not any(isinstance(r, Request) for r in results)


### PR DESCRIPTION
**What was broken:** institutional research repositories (Islandora, DSpace, Fedora fronts) are often effectively uncrawlable as HTML: a Cloudflare Turnstile puzzle on every page plus a `Crawl-delay: 120` robots rule means ~20–30k documents would take weeks — while the same sites expose a fully open, puzzle-free machine API (Drupal JSON:API) that lists the complete repository. scrapai had no way to ingest a paginated JSON collection.

**What it does now:** a new spider type walks the JSON collection endpoint page by page and maps each record into a normal pipeline item. The mapping lives entirely in the spider's JSON config (`REPOSITORY_SOURCE`): field dot-paths with `||` fallbacks, JSON:API `include` relationship resolution, URL templates, and the standard processor chain. Setting it routes the crawl to the new spider; every existing HTML/sitemap spider is untouched.

## Details

- New `spiders/repository_spider.py` (`repository_database_spider`): follows the `next` link until absent; records failing a `require` field (e.g. unpublished parent omitted from `included`) are skipped, not errored.
- `cli/crawl.py`: a non-empty `REPOSITORY_SOURCE` setting routes to it, alongside the existing `USE_SITEMAP` routing.
- First target: an institutional research repository (~20–30k PDFs) — weeks of Turnstile crawling become one polite pass.
- Note: the config validator caps `DOWNLOAD_DELAY` at 60, so spiders honoring a `Crawl-delay: 120` import with `--skip-validation`.
- Request doc: `docs/requests/21-jsonapi-repository-harvest.md` (port of the pre-migration repo's request 11).

## Behavior changes

- None for existing spiders: the new spider only activates when a config sets `REPOSITORY_SOURCE`; all HTML/sitemap routing is untouched.

## Verified

8 unit tests (`tests/unit/test_repository_spider.py`): dot-path walker, `||` fallbacks, full item mapping (template + include resolution + processors), missing-include → null, `require` skip, pagination follow and stop, malformed records, item-limit cutoff. The design is a port of code proven in production in the pre-migration repo.

**Merge note:** touches `cli/crawl.py`, as do PRs 17/18/19 — merging in numeric order minimizes conflicts.
