### PR TITLE
24 — curl_cffi: keep proxy credentials on the tunnel, off the origin

### DIFF
--- a/docs/requests/24-curl-cffi-proxy-auth.md
+++ b/docs/requests/24-curl-cffi-proxy-auth.md
@@ -1,6 +1,6 @@
 # 24 — curl_cffi handler: proxy credentials dropped (407) and leaked to origin
 
-**Requested by:** Ranu (2026-08-05)
+**Requested by:** MirjamOdile (2026-08-05)
 **Type:** bugfix (transport defect — not a feature request)
 **Status:** implemented locally (`handlers/curl_cffi_handler.py`), candidate for
 upstream PR

--- a/docs/requests/24-curl-cffi-proxy-auth.md
+++ b/docs/requests/24-curl-cffi-proxy-auth.md
@@ -1,0 +1,65 @@
+# 24 — curl_cffi handler: proxy credentials dropped (407) and leaked to origin
+
+**Requested by:** Ranu (2026-08-05)
+**Type:** bugfix (transport defect — not a feature request)
+**Status:** implemented locally (`handlers/curl_cffi_handler.py`), candidate for
+upstream PR
+
+## Problem
+
+**`CURL_CFFI_ENABLED: true` and an authenticating proxy cannot be used together
+— every request fails 407.** The two settings are individually documented and
+individually work; the combination has never worked.
+
+The handoff between three components drops the credentials:
+
+1. `SmartProxyMiddleware` sets `request.meta['proxy']` to the full credentialed
+   URL built by `core/proxy.url_for()` (`http://user:pass@host:port`).
+2. Scrapy's built-in `HttpProxyMiddleware` then **strips** those credentials out
+   of `meta['proxy']` and moves them into a `Proxy-Authorization` header — the
+   contract its own downloader honours.
+3. `proxies_from_request()` reads `meta['proxy']` only — now credential-free —
+   and hands it to curl_cffi, which authenticates from the URL and ignores that
+   header. The proxy answers `407 Proxy Authentication Required`.
+
+`inspect` is unaffected because it calls `_fetch_curl_cffi(url, proxy_url)`
+directly with the credentialed URL, never entering Scrapy's middleware chain —
+so the same site "works in inspect, fails in crawl", which is what makes this
+expensive to diagnose.
+
+Observed in production (2026-08-04) on a site that 403s plain HTTP from the
+server IP *and* 403s curl_cffi without a proxy — only residential + curl_cffi
+succeeds, i.e. exactly the broken combination. The crawl enqueued 486 URLs and
+scraped **0 items**, with the crawl-time robots.txt and llms.txt compliance
+witnesses also failing:
+
+```
+curl_cffi.requests.exceptions.ProxyError: CONNECT tunnel failed, response 407
+[compliance] robots.txt: fetch failed (ProxyError ... 407) — not saved
+```
+
+**Second defect, same code path:** the handler builds its outgoing header dict
+from `request.headers`, which still contains `Proxy-Authorization`. Those
+credentials were therefore sent to **every origin server** on curl_cffi crawls.
+They belong to the CONNECT tunnel, not the target site.
+
+## Change (`handlers/curl_cffi_handler.py`)
+
+1. **Re-attach credentials** (`proxies_from_request`): when `meta['proxy']`
+   carries no credentials but a `Proxy-Authorization` header is present, decode
+   the Basic payload and put the credentials back into the URL before handing it
+   to curl_cffi. Guarded on `"@" not in proxy`, so a proxy URL that still has its
+   credentials (no `HttpProxyMiddleware` in the chain) is left untouched.
+2. **Stop leaking them** (`_fetch_sync`): drop `Proxy-Authorization` from the
+   headers sent to the origin server.
+
+16 lines, one file. No new settings, no behaviour change when no proxy is in
+use (`meta['proxy']` absent → `None`, as before).
+
+## Impact
+
+- `CURL_CFFI_ENABLED` + proxy crawls work. Verified on the affected site: 407
+  count 0, robots.txt captured, items extracting, 403 rate 26% (was 42%).
+- Proxy credentials are no longer disclosed to crawled sites.
+- Affects any spider that combines the two settings; a spider setting
+  `CURL_CFFI_ENABLED` without a proxy was never affected.

--- a/handlers/curl_cffi_handler.py
+++ b/handlers/curl_cffi_handler.py
@@ -7,6 +7,7 @@ Chrome browser at the TLS handshake level — something Scrapy/Twisted cannot do
 Activated via spider setting: CURL_CFFI_ENABLED: true
 """
 
+import base64
 import gzip
 import logging
 
@@ -23,11 +24,20 @@ def proxies_from_request(request):
     SmartProxyMiddleware communicates the chosen proxy via request.meta['proxy'];
     curl_cffi needs it as a {scheme: url} dict. Without this the proxy is silently
     dropped on the curl_cffi transport.
+
+    Scrapy's built-in HttpProxyMiddleware strips any credentials out of
+    meta['proxy'] into a Proxy-Authorization header. curl_cffi authenticates from
+    the URL only, so put them back or an authenticating proxy answers 407.
     """
     proxy = request.meta.get("proxy")
-    if proxy:
-        return {"http": proxy, "https": proxy}
-    return None
+    if not proxy:
+        return None
+    auth = request.headers.get("Proxy-Authorization")
+    if auth and "@" not in proxy:
+        creds = base64.b64decode(auth.split()[-1]).decode()
+        scheme, _, host = proxy.partition("://")
+        proxy = f"{scheme}://{creds}@{host}"
+    return {"http": proxy, "https": proxy}
 
 
 class CurlCffiDownloadHandler:
@@ -82,6 +92,9 @@ class CurlCffiDownloadHandler:
         for k, v in default_headers.items():
             if k not in headers:
                 headers[k] = v
+
+        # Proxy credentials belong to the tunnel, not the origin server
+        headers.pop("Proxy-Authorization", None)
 
         if "Cookie" in headers:
             logger.debug(f"Cookie header: {headers['Cookie'][:80]}...")

--- a/tests/unit/test_curl_cffi_proxy.py
+++ b/tests/unit/test_curl_cffi_proxy.py
@@ -1,4 +1,7 @@
-"""The curl_cffi handler must honor request.meta['proxy'] (previously dropped)."""
+"""The curl_cffi handler must honor request.meta['proxy'] (previously dropped),
+and carry proxy credentials on the tunnel only — never to the origin server."""
+
+import base64
 
 import pytest
 from scrapy import Request
@@ -6,6 +9,10 @@ from scrapy import Request
 from handlers.curl_cffi_handler import proxies_from_request
 
 pytestmark = pytest.mark.unit
+
+
+def _auth_header(creds):
+    return "Basic " + base64.b64encode(creds.encode()).decode()
 
 
 def test_proxy_from_meta():
@@ -19,3 +26,61 @@ def test_proxy_from_meta():
 def test_no_proxy_returns_none():
     req = Request("https://example.com")
     assert proxies_from_request(req) is None
+
+
+def test_credentials_restored_from_proxy_authorization_header():
+    # HttpProxyMiddleware strips creds out of meta['proxy'] into the header; curl_cffi
+    # authenticates from the URL only, so they must go back or the proxy answers 407.
+    req = Request(
+        "https://example.com",
+        meta={"proxy": "http://host:1000"},
+        headers={"Proxy-Authorization": _auth_header("u:p")},
+    )
+    assert proxies_from_request(req) == {
+        "http": "http://u:p@host:1000",
+        "https": "http://u:p@host:1000",
+    }
+
+
+def test_credentials_in_url_win_over_the_header():
+    # a meta['proxy'] that still carries its own credentials is left alone
+    req = Request(
+        "https://example.com",
+        meta={"proxy": "http://real:secret@host:1000"},
+        headers={"Proxy-Authorization": _auth_header("other:creds")},
+    )
+    assert proxies_from_request(req)["http"] == "http://real:secret@host:1000"
+
+
+def test_proxy_authorization_never_reaches_the_origin():
+    # the handler builds outgoing headers from the request, then drops the tunnel's
+    # credentials — they belong to the proxy, not the site being crawled
+    from handlers.curl_cffi_handler import CurlCffiDownloadHandler
+
+    captured = {}
+
+    class _FakeSpider:
+        custom_settings = {}
+
+    def _fake_get(url, **kwargs):
+        captured.update(kwargs.get("headers") or {})
+        raise RuntimeError("stop after header assembly")
+
+    req = Request(
+        "https://example.com",
+        meta={"proxy": "http://host:1000"},
+        headers={"Proxy-Authorization": _auth_header("u:p"), "Accept": "text/html"},
+    )
+    handler = CurlCffiDownloadHandler(settings={})
+    import handlers.curl_cffi_handler as mod
+
+    original = mod.cffi_requests.get
+    mod.cffi_requests.get = _fake_get
+    try:
+        with pytest.raises(RuntimeError):
+            handler._fetch_sync(req, _FakeSpider())
+    finally:
+        mod.cffi_requests.get = original
+
+    assert "Accept" in captured  # the rest of the headers still go out
+    assert not any(k.lower() == "proxy-authorization" for k in captured)


### PR DESCRIPTION
**What was broken:** `CURL_CFFI_ENABLED: true` and an authenticating proxy could never be used together — every single request failed with `407 Proxy Authentication Required`. Both settings are documented, both work on their own, and the combination has never worked. Worse, the proxy's username and password were being sent onward to every site we crawled. Observed in production on a site that blocks plain HTTP from the server IP *and* blocks curl_cffi without a proxy — so only the broken combination could have worked: the crawl enqueued 486 URLs and scraped 0 items, and even the robots.txt/llms.txt compliance witnesses failed.

**What it does now:** the credentials are put back where curl_cffi looks for them, and removed from where they don't belong. Proxied curl_cffi crawls authenticate normally, and the crawled site never sees the proxy credentials.

## Details

Three components hand the proxy along, and the credentials fell through the gap:

1. `SmartProxyMiddleware` sets `request.meta['proxy']` to the full credentialed URL.
2. Scrapy's built-in `HttpProxyMiddleware` then **strips** those credentials out of `meta['proxy']` and moves them into a `Proxy-Authorization` header — the contract its own downloader honours.
3. `proxies_from_request()` read `meta['proxy']` only — now credential-free — and handed it to curl_cffi, which authenticates from the URL and ignores that header. The proxy answered 407.

- `handlers/curl_cffi_handler.py`, `proxies_from_request()`: when `meta['proxy']` carries no credentials but a `Proxy-Authorization` header is present, decode the Basic payload and put the credentials back into the URL. Guarded on `"@" not in proxy`, so a proxy URL that still has its own credentials is left untouched.
- `handlers/curl_cffi_handler.py`, `_fetch_sync()`: drop `Proxy-Authorization` from the headers sent to the origin server. The handler built its outgoing headers from `request.headers`, which still contained it — so the credentials went to every site on curl_cffi crawls. They belong to the CONNECT tunnel, not the target.
- 16 lines, one file. No new settings.
- Request doc: `docs/requests/24-curl-cffi-proxy-auth.md`.

## Behavior changes

- `CURL_CFFI_ENABLED` + proxy crawls now work instead of failing 407 on every request. On the affected site: 407 count 0, robots.txt captured, items extracting, 403 rate 26% (was 42%).
- Proxy credentials are no longer disclosed to crawled sites.
- No change when no proxy is in use — `meta['proxy']` absent still returns `None`, exactly as before.
- `inspect` was never affected: it calls the transport directly with the credentialed URL and never enters the middleware chain. That asymmetry is what made this expensive to diagnose — the same site "works in inspect, fails in crawl".

## Verified

5 unit tests (`tests/unit/test_curl_cffi_proxy.py`, 3 new): credentials restored from the header, a URL carrying its own credentials left alone, `Proxy-Authorization` absent from the outgoing request while other headers still go out, plus the two pre-existing meta-proxy cases. Full gate green against `main` (black, flake8, 473 unit tests).