### PR TITLE
25 — cloudflare: add browser_only strategy for full-browser per-request rendering

### DIFF
--- a/handlers/cloudflare_handler.py
+++ b/handlers/cloudflare_handler.py
@@ -1,15 +1,21 @@
 """
 Scrapy download handler for Cloudflare-protected sites.
 
-This handler uses a hybrid approach:
-1. A central browser verifies CF once per host (cookies are per-hostname) to get
-   the CF cookie. Verification is held at one gate, so concurrent requests never
-   drive the browser at the same time.
-2. Fast concurrent HTTP requests with the cached cookie for everything else.
-3. Reactive (not time-based) reverify: only when a host has no cookie yet, or an
-   HTTP response comes back blocked. On a block, all requests hold, ONE
-   reverifies, everyone retries with the fresh cookie — so a transient cookie
-   death pauses briefly instead of failing requests.
+This handler supports two strategies, selected by CLOUDFLARE_STRATEGY:
+
+hybrid (default, fast):
+  1. A central browser verifies CF once per host (cookies are per-hostname) to
+     get the CF cookie. Verification is held at one gate, so concurrent requests
+     never drive the browser at the same time.
+  2. Fast concurrent HTTP requests with the cached cookie for everything else.
+  3. Reactive (not time-based) reverify: only when a host has no cookie yet, or
+     an HTTP response comes back blocked. On a block, all requests hold, ONE
+     reverifies, everyone retries with the fresh cookie.
+
+browser_only (slow, for JS-rendered SPAs that need a real browser every page):
+  Every request is rendered by the shared browser service via cf_verify, which
+  navigates the already-verified browser to the target URL and returns the fully
+  rendered DOM. No HTTP fallback. Requires CONCURRENT_REQUESTS=1.
 """
 
 import asyncio
@@ -164,7 +170,7 @@ class CloudflareDownloadHandler:
             logger.info("CloudflareDownloadHandler: Stopped persistent event loop")
 
     def download_request(self, request: Request, spider):
-        """Handle request: browser verifies a host once, HTTP does the rest.
+        """Dispatch to hybrid or browser-only fetch based on CLOUDFLARE_STRATEGY.
 
         Note: This handler is only used when spider explicitly enables
         CLOUDFLARE_ENABLED=True in settings.
@@ -176,7 +182,47 @@ class CloudflareDownloadHandler:
         Returns:
             Deferred that resolves to HtmlResponse
         """
+        strategy = (
+            getattr(spider, "custom_settings", {})
+            .get("CLOUDFLARE_STRATEGY", "hybrid")
+            .lower()
+        )
+        if strategy == "browser_only":
+            return threads.deferToThread(
+                self._browser_only_fetch_sync, request, spider
+            )
         return threads.deferToThread(self._hybrid_fetch_sync, request, spider)
+
+    def _browser_only_fetch_sync(self, request: Request, spider):
+        """Browser-only mode: every request rendered by the shared browser service.
+
+        Calls _verify_via_service for every URL, which drives the already-warm
+        browser (CF already solved after the first hit) to navigate and return the
+        fully rendered DOM. No HTTP fallback — use only when the site is a pure
+        CSR SPA that yields no useful content over plain HTTP.
+        """
+        try:
+            html = CloudflareDownloadHandler._run_async(
+                self._browser_only_fetch_async(request, spider)
+            )
+            self._stop_if_session_expired(html, spider)
+            if html:
+                return _make_response(request.url, html, request)
+            raise Exception(f"Browser-only fetch returned no HTML for {request.url}")
+        except Exception as e:
+            logger.error(f"Browser-only fetch error for {request.url}: {e}")
+            raise
+
+    async def _browser_only_fetch_async(self, request: Request, spider):
+        """Route every request through the shared browser service (cf_verify action)."""
+        result = await self._verify_via_service(request.url, spider)
+        if result is None:
+            raise Exception(
+                f"Browser service unreachable for {request.url} "
+                "(request will be retried)"
+            )
+        html, _cookies, _user_agent = result
+        return html
 
     def _hybrid_fetch_sync(self, request: Request, spider):
         """Hybrid mode: browser once + HTTP with cookies (fast). Runs in thread."""
@@ -320,18 +366,37 @@ class CloudflareDownloadHandler:
         mistakenly-stopped service self-heals instead of every crawl spawning its
         own browser. Returns (html, cookies, user_agent), or None if the service
         still isn't reachable (caller then falls back to a local browser). The
-        blocking socket/startup work runs in an executor so the loop never stalls."""
+        blocking socket/startup work runs in an executor so the loop never stalls.
+
+        CF_WAIT_SELECTOR (optional spider setting): CSS selector to wait for
+        before capturing the rendered DOM. Useful for JS-heavy SPAs where
+        content loads asynchronously after DOMContentLoaded.
+        CF_WAIT_TIMEOUT: seconds to wait for the selector (default 10).
+        """
         from utils import browser_client
 
-        session_name = getattr(spider, "custom_settings", {}).get("SESSION")
+        spider_settings = getattr(spider, "custom_settings", {})
+        session_name = spider_settings.get("SESSION")
+        wait_selector = spider_settings.get("CF_WAIT_SELECTOR")
+        wait_timeout = spider_settings.get("CF_WAIT_TIMEOUT", 10)
 
         def _call():
-            resp = browser_client.request("cf_verify", url=url, session=session_name)
+            resp = browser_client.request(
+                "cf_verify",
+                url=url,
+                session=session_name,
+                wait_selector=wait_selector,
+                wait_timeout=wait_timeout,
+            )
             if resp is None:
                 # Service down (e.g. someone ran `browser stop`) — restart + retry.
                 if browser_client.ensure_running():
                     resp = browser_client.request(
-                        "cf_verify", url=url, session=session_name
+                        "cf_verify",
+                        url=url,
+                        session=session_name,
+                        wait_selector=wait_selector,
+                        wait_timeout=wait_timeout,
                     )
             return resp
 
@@ -342,6 +407,7 @@ class CloudflareDownloadHandler:
         if not resp.get("ok"):
             raise Exception(f"Browser service failed to verify CF for {url}")
         return resp["html"], resp["cookies"], resp["user_agent"]
+
 
     async def _fetch_with_http(self, url: str, cached: Dict) -> Optional[str]:
         """Fetch URL with HTTP + cached cookies using curl_cffi for TLS stealth."""

--- a/tests/unit/test_browser_service.py
+++ b/tests/unit/test_browser_service.py
@@ -166,3 +166,61 @@ async def test_inspect_without_path_skips_screenshot(monkeypatch):
     )
     assert resp["ok"] is True
     assert calls["n"] == 0  # no path -> no screenshot
+
+
+# ---------------------------------------------------------------------------
+# cf_browser.fetch() — wait_selector on first fetch (cf_verified=False)
+# ---------------------------------------------------------------------------
+
+
+async def test_cf_browser_fetch_applies_wait_selector_on_first_request(monkeypatch):
+    """wait_selector must be honoured on the very first URL per domain.
+
+    Before the fix, fetch() only called wait_for_selector in the
+    'subsequent requests' branch (cf_verified=True). On the first request
+    (cf_verified=False) it used a hardcoded sleep(3) and returned immediately,
+    so a CSR SPA's start_url came back as a half-hydrated shell.
+    """
+    from utils.cf_browser import CloudflareBrowserClient
+
+    client = CloudflareBrowserClient()
+
+    # Stub out the real browser: CF verify always succeeds immediately.
+    async def fake_verify_cloudflare(url):
+        client.cf_verified = True
+        return True
+
+    monkeypatch.setattr(client, "verify_cloudflare", fake_verify_cloudflare)
+
+    # Minimal page mock: goto succeeds, content() returns rendered HTML.
+    page = Mock()
+
+    async def fake_goto(url, wait_until=None, timeout=None):
+        return None
+
+    page.goto = fake_goto
+
+    selector_waits = []
+
+    async def fake_wait_for_selector(selector, timeout=None):
+        selector_waits.append(selector)
+
+    page.wait_for_selector = fake_wait_for_selector
+
+    async def fake_content():
+        return "<html><div class='app'>hydrated</div></html>"
+
+    page.content = fake_content
+
+    client.page = page
+    # Initialise the fetch lock so the lock-init branch is skipped.
+    client.fetch_lock = asyncio.Lock()
+
+    html = await client.fetch(
+        "https://example.com/jobs", wait_selector=".app", wait_timeout=5
+    )
+
+    assert selector_waits == [".app"], (
+        "wait_for_selector was not called on the first (cf_verified=False) fetch"
+    )
+    assert "hydrated" in html

--- a/tests/unit/test_browser_service.py
+++ b/tests/unit/test_browser_service.py
@@ -32,7 +32,7 @@ class FakeLane:
     def __init__(self):
         self.page = Mock()
 
-    async def fetch(self, url):
+    async def fetch(self, url, wait_selector=None, wait_timeout=10):
         return "<html>body</html>" * 1000  # > 0 bytes
 
 

--- a/tests/unit/test_cloudflare_handler.py
+++ b/tests/unit/test_cloudflare_handler.py
@@ -335,3 +335,94 @@ class TestHandlerLifecycle:
         await handler.close(spider)
 
         assert "cleanup_spider" not in CloudflareDownloadHandler._cookie_cache
+
+
+class TestBrowserOnlyStrategy:
+    """browser_only routes every request through the browser service (cf_verify)."""
+
+    def _spider(self, strategy="browser_only"):
+        s = Mock()
+        s.name = "test_spider"
+        s.custom_settings = {"CLOUDFLARE_STRATEGY": strategy}
+        return s
+
+    @pytest.mark.unit
+    def test_download_request_routes_to_browser_only(self, monkeypatch):
+        """CLOUDFLARE_STRATEGY='browser_only' dispatches to _browser_only_fetch_sync."""
+        handler = CloudflareDownloadHandler({})
+        spider = self._spider("browser_only")
+        request = Request("https://example.com/job/1")
+
+        calls = []
+
+        def fake_browser_only(req, sp):
+            calls.append(("browser_only", req.url))
+
+        def fake_hybrid(req, sp):
+            calls.append(("hybrid", req.url))
+
+        monkeypatch.setattr(handler, "_browser_only_fetch_sync", fake_browser_only)
+        monkeypatch.setattr(handler, "_hybrid_fetch_sync", fake_hybrid)
+
+        from twisted.internet import threads as tw_threads
+        monkeypatch.setattr(
+            tw_threads, "deferToThread",
+            lambda fn, *args: fn(*args),
+        )
+
+        handler.download_request(request, spider)
+        assert calls == [("browser_only", "https://example.com/job/1")]
+
+    @pytest.mark.unit
+    def test_download_request_default_is_hybrid(self, monkeypatch):
+        """No CLOUDFLARE_STRATEGY (or 'hybrid') defaults to hybrid path."""
+        handler = CloudflareDownloadHandler({})
+        spider = self._spider("hybrid")
+        request = Request("https://example.com/job/2")
+
+        calls = []
+
+        monkeypatch.setattr(handler, "_browser_only_fetch_sync", lambda r, s: calls.append("browser_only"))
+        monkeypatch.setattr(handler, "_hybrid_fetch_sync", lambda r, s: calls.append("hybrid"))
+
+        from twisted.internet import threads as tw_threads
+        monkeypatch.setattr(
+            tw_threads, "deferToThread",
+            lambda fn, *args: fn(*args),
+        )
+
+        handler.download_request(request, spider)
+        assert calls == ["hybrid"]
+
+    @pytest.mark.unit
+    async def test_browser_only_fetch_async_calls_verify_via_service(self, monkeypatch):
+        """_browser_only_fetch_async delegates to _verify_via_service and returns html."""
+        handler = CloudflareDownloadHandler({})
+        spider = self._spider()
+        request = Request("https://example.com/job/3")
+
+        async def fake_verify(url, sp):
+            return "<html>rendered</html>", {"cf_clearance": "tok"}, "UA"
+
+        monkeypatch.setattr(handler, "_verify_via_service", fake_verify)
+
+        html = await handler._browser_only_fetch_async(request, spider)
+        assert html == "<html>rendered</html>"
+
+    @pytest.mark.unit
+    async def test_browser_only_fetch_async_raises_when_service_unreachable(
+        self, monkeypatch
+    ):
+        """_browser_only_fetch_async raises when browser service is None."""
+        handler = CloudflareDownloadHandler({})
+        spider = self._spider()
+        request = Request("https://example.com/job/4")
+
+        async def fake_verify(url, sp):
+            return None  # service unreachable
+
+        monkeypatch.setattr(handler, "_verify_via_service", fake_verify)
+
+        with pytest.raises(Exception, match="Browser service unreachable"):
+            await handler._browser_only_fetch_async(request, spider)
+

--- a/utils/browser_service.py
+++ b/utils/browser_service.py
@@ -129,10 +129,17 @@ async def handle_request(pool, req, stop):
     if action == "cf_verify":
         # Drive the central browser to clear CF for this host, then return the
         # HTML + host-scoped cookies + UA so the crawl can do fast HTTP itself.
+        # In browser_only mode the handler calls cf_verify for every URL, so
+        # wait_selector / wait_timeout are honoured here to let React apps finish
+        # rendering before the DOM is captured.
         domain = _domain(req["url"])
         lane = await pool.acquire(domain, _session_file(req))
         async with _nav_lock(domain):
-            html = await lane.fetch(req["url"])
+            html = await lane.fetch(
+                req["url"],
+                wait_selector=req.get("wait_selector"),
+                wait_timeout=req.get("wait_timeout", 10),
+            )
             if not html:
                 return {"ok": False, "error": "verify failed"}
             cookies = await _lane_cookies(lane, req["url"])

--- a/utils/cf_browser.py
+++ b/utils/cf_browser.py
@@ -535,7 +535,30 @@ class CloudflareBrowserClient:
                     else:
                         raise
 
-                await asyncio.sleep(3)
+                await asyncio.sleep(1)
+
+                # Wait for specific selector if requested.
+                # This is needed for CSR SPAs on the very first request per
+                # domain: CF verify leaves cf_verified=False until this branch
+                # completes, so without this check the first page of a React/
+                # Vue/Aurelia site is captured before the app finishes hydrating.
+                if wait_selector:
+                    logger.info(
+                        f"Waiting for selector '{wait_selector}' "
+                        f"(timeout: {wait_timeout}s)"
+                    )
+                    try:
+                        await self.page.wait_for_selector(
+                            wait_selector, timeout=wait_timeout * 1000
+                        )
+                        logger.info(f"Selector '{wait_selector}' found")
+                        await asyncio.sleep(1)
+                    except Exception as e:
+                        logger.warning(f"Timeout waiting for selector: {e}")
+                        await asyncio.sleep(1.5)
+                else:
+                    await asyncio.sleep(2)
+
                 html = await self._body_or_dom(response)
                 logger.info(f"Fetched {len(html)} bytes from {url}")
                 return html


### PR DESCRIPTION
**What was broken:** `CLOUDFLARE_ENABLED` uses a hybrid strategy — browser once to solve CF, then fast HTTP with cached cookies for everything else. On CSR SPAs (React, Vue, Aurelia, and similar frameworks) every HTTP response is a near-empty JS shell, so extraction silently returns all fields null with no error or warning.

`browser_only` was previously available to handle this case but was correctly removed in `2ed37dc` because the old implementation started a per-crawl Chromium process and duplicated proxy-chain logic from `core/proxy`. That removal left no supported path for CSR SPAs under Cloudflare protection.

**What it does now:** a new `CLOUDFLARE_STRATEGY` spider setting (values: `hybrid` [default, unchanged], `browser_only`) routes every download through the shared browser service's existing `cf_verify` action. After the first call — which clears CF — the lane's browser navigates to each subsequent URL and returns the fully rendered DOM. No new browser process is spawned; this is not a revert of `2ed37dc`. The already-warm shared service handles everything.

As a side effect, `CF_WAIT_SELECTOR` and `CF_WAIT_TIMEOUT` — previously accepted by spider configs but silently dropped before reaching `lane.fetch` — now take effect for both strategies, so SPAs can declare a CSS selector that signals full hydration before the DOM is captured.

Closes #21.

## Details

- `handlers/cloudflare_handler.py`
  - `download_request`: reads `CLOUDFLARE_STRATEGY` from `spider.custom_settings`, dispatches to `_browser_only_fetch_sync` or the existing `_hybrid_fetch_sync`
  - `_browser_only_fetch_sync` / `_browser_only_fetch_async`: call `_verify_via_service` for every URL and return the rendered HTML
  - `_verify_via_service`: now reads `CF_WAIT_SELECTOR` / `CF_WAIT_TIMEOUT` from spider settings and forwards them to the browser service

- `utils/browser_service.py`
  - `cf_verify` action: passes `wait_selector` / `wait_timeout` into `lane.fetch` (previously those keys were accepted in the request payload but never forwarded)

## Behavior changes

- **No change to existing spiders.** `CLOUDFLARE_STRATEGY` defaults to `hybrid`, preserving current behavior exactly.
- **`CF_WAIT_SELECTOR` / `CF_WAIT_TIMEOUT` now take effect.** If a spider already sets these, hydration will be awaited before DOM capture. If unset, no wait occurs — same as before.
- **`browser_only` requires `CONCURRENT_REQUESTS=1`** — the browser lane is sequential; concurrent navigation is not supported.

## Verified

4 new unit tests (`TestBrowserOnlyStrategy`): routing to the `browser_only` path, default still routes to `hybrid`, async delegation to `_verify_via_service`, and service-unreachable raises with a retryable message. `FakeLane.fetch` updated to accept the new `wait_selector` kwarg without breaking existing tests. All 32 unit tests pass.